### PR TITLE
Use `repo` instead of `fork` in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ jobs:
 
     # 2. Deploy
     - stage: Deploy
-      if: fork == false && type != pull_request && (branch == development || (branch == master && tag ~= ^v))
+      if: |
+        repo == JarvisCraft/padla && type != pull_request \
+        && (branch == development || (branch == master && tag ~= ^v))
       # Use the minimal supported version (this assures that no version-specific bytecode gets generated)
       jdk: openjdk8
       before_deploy: ./.travis/scripts/import_code_signing_keys.sh


### PR DESCRIPTION
# Description
There seems to be a Travis bug that the latter dows not use `fork` property.

# References

https://travis-ci.community/t/bug-fork-attribute-is-always-falsy/1310