### PR TITLE
Add more nullsafety extensions

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/LegacyOptionalExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/LegacyOptionalExtensions.java
@@ -1,0 +1,181 @@
+package ru.progrm_jarvis.javacommons.object.extension;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.lang.invoke.MethodType.methodType;
+
+/**
+ * Extensions to provide new {@link Optional} methods on older Java versions.
+ */
+@UtilityClass
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType") // this is the whole concept of this class
+public class LegacyOptionalExtensions {
+
+    /**
+     * Method handle of
+     * {@link Optional}{@code .ifPresentOrElse(}{@link Consumer}{@code , }{@link Runnable}{@code )} method
+     * being {@code null} if this method is unavailable.
+     */
+    private final @Nullable MethodHandle IF_PRESENT_OR_ELSE_METHOD_HANDLE;
+
+    /**
+     * Method handle of
+     * {@link Optional}{@code .or(}{@link Supplier}{@code <? extends }{@link Object}{@code >>)} method
+     * being {@code null} if this method is unavailable.
+     */
+    private final @Nullable MethodHandle OR_METHOD_HANDLE;
+
+    /**
+     * Method handle of
+     * {@link Optional}{@code .stream()} method
+     * being {@code null} if this method is unavailable.
+     */
+    private final @Nullable MethodHandle STREAM_METHOD_HANDLE;
+
+    /**
+     * Method handle of
+     * {@link Optional}{@code .orElseThrow()} method
+     * being {@code null} if this method is unavailable.
+     */
+    private final @Nullable MethodHandle OR_ELSE_THROW_METHOD_HANDLE;
+
+    static {
+        val lookup = MethodHandles.lookup();
+        {
+            MethodHandle handle;
+            try {
+                handle = lookup.findVirtual(
+                        Optional.class, "ifPresentOrElse", methodType(void.class, Consumer.class, Runnable.class)
+                );
+            } catch (final NoSuchMethodException | IllegalAccessException e) {
+                handle = null;
+            }
+            IF_PRESENT_OR_ELSE_METHOD_HANDLE = handle;
+        }
+        {
+            MethodHandle handle;
+            try {
+                handle = lookup.findVirtual(
+                        Optional.class, "or", methodType(Optional.class, Supplier.class)
+                );
+            } catch (final NoSuchMethodException | IllegalAccessException e) {
+                handle = null;
+            }
+            OR_METHOD_HANDLE = handle;
+        }
+        {
+            MethodHandle handle;
+            try {
+                handle = lookup.findVirtual(
+                        Optional.class, "stream", methodType(Stream.class)
+                );
+            } catch (final NoSuchMethodException | IllegalAccessException e) {
+                handle = null;
+            }
+            STREAM_METHOD_HANDLE = handle;
+        }
+        {
+            MethodHandle handle;
+            try {
+                handle = lookup.findVirtual(
+                        Optional.class, "orElseThrow", methodType(Object.class)
+                );
+            } catch (final NoSuchMethodException | IllegalAccessException e) {
+                handle = null;
+            }
+            OR_ELSE_THROW_METHOD_HANDLE = handle;
+        }
+    }
+
+    /**
+     * Runs the corresponding action depending on whether the optional is {@link Optional#isPresent() present}.
+     *
+     * @param optional optional on which the operation happens
+     * @param action action to be run on non-{@link Optional#empty() empty} optional's value
+     * @param emptyAction action to be run if the optional is empty
+     * @param <T> type of the value
+     * @throws NullPointerException if the optional is {@link Optional#isPresent() present} but {@code action} is {@code
+     * null}
+     * or if the optional is {@link Optional#empty() empty} but {@code emptyAction} is {@code null}
+     * @apiNote this method is available on {@link Optional} itself since Java 9
+     */
+    @SneakyThrows // call to `MethodHandle#invokeExact(...)`
+    public <T> void ifPresentOrElse(final @NotNull Optional<T> optional,
+                                    // note: nullness checking of lambdas is done lazily according to the contract
+                                    final @NotNull Consumer<? super T> action,
+                                    final @NotNull Runnable emptyAction) {
+        if (IF_PRESENT_OR_ELSE_METHOD_HANDLE == null) if (optional.isPresent()) action.accept(optional.get());
+        else emptyAction.run();
+        else IF_PRESENT_OR_ELSE_METHOD_HANDLE.invokeExact(optional, action, emptyAction);
+    }
+
+    /**
+     * Returns the given optional if it is {@link Optional#isPresent() present}
+     * or an optional provided by the given supplier otherwise.
+     *
+     * @param optional optional on which the operation happens
+     * @param supplier supplier of the value in case of optional being {@link Optional#isEmpty() empty}
+     * @param <T> type of the value
+     * @return given optional if it is {@link Optional#isPresent() present}
+     * or an optional provided by the given supplier otherwise
+     *
+     * @throws NullPointerException if {@code supplier} is {@code null}
+     * @apiNote this method is available on {@link Optional} itself since Java 9
+     */
+    @Contract("_, null -> fail")
+    @SneakyThrows // call to `MethodHandle#invokeExact(...)`
+    @SuppressWarnings({"unchecked" /* return casts */, "Contract" /* // Lombok's annotation is treated incorrectly */})
+    public <T> Optional<T> or(final @NotNull Optional<T> optional,
+                              final @NonNull Supplier<? extends Optional<? extends T>> supplier) {
+        return OR_METHOD_HANDLE == null
+                ? optional.isPresent() ? optional : (Optional<T>) supplier.get()
+                : (Optional<T>) OR_METHOD_HANDLE.invokeExact(optional, supplier);
+    }
+
+    /**
+     * Returns the {@link Stream stream} created from the optional's value if it is {@link Optional#isPresent() present}
+     * or an {@link Stream#empty() empty stream} otherwise.
+     *
+     * @param optional optional on which the operation happens
+     * @param <T> type of the value
+     * @return given optional if it is {@link Optional#isPresent() present}
+     * or an optional provided by the given supplier otherwise
+     */
+    @SuppressWarnings("unchecked") // return cast
+    @SneakyThrows // call to `MethodHandle#invokeExact(...)`
+    public <T> Stream<T> stream(final @NotNull Optional<T> optional) {
+        return STREAM_METHOD_HANDLE == null
+                ? optional.map(Stream::of).orElseGet(Stream::empty)
+                : (Stream<T>) STREAM_METHOD_HANDLE.invokeExact(optional);
+    }
+
+    /**
+     * Returns the value of the optional if it is {@link Optional#isPresent() present}
+     * or throws {@link NoSuchElementException} otherwise.
+     *
+     * @param optional optional on which the operation happens
+     * @param <T> type of the value
+     * @return the value of the optional if it is {@link Optional#isPresent() present}
+     */
+    @SuppressWarnings("unchecked") // return cast
+    @SneakyThrows // call to `MethodHandle#invokeExact(...)`
+    public <T> T orElseThrow(final @NotNull Optional<T> optional) {
+        return STREAM_METHOD_HANDLE == null
+                ? optional.orElseThrow(() -> new NoSuchElementException("No value present"))
+                : (T) STREAM_METHOD_HANDLE.invokeExact(optional);
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
@@ -133,12 +133,33 @@ public class NullSafetyExtensions {
      * @throws X if {@code value} is null
      * @throws NullPointerException if {@code throwableSupplier} or it supplies {@code null}
      */
+    @SuppressWarnings("Contract") // Lombok's annotation is treated incorrectly
+    @Contract("null, _ -> fail; _, null -> fail; _, _ -> param1")
     public <T, X extends Throwable> @NotNull T _orElseThrow(final @Nullable T value,
                                                             final @NonNull Supplier<@NonNull X>
                                                                     throwableSupplier) throws X {
         if (value == null) throw throwableSupplier.get();
 
         return value;
+    }
+
+    /**
+     * Runs the corresponding action depending on whether the value is {@code null}.
+     *
+     * @param value value to be checked
+     * @param action action to be run on non-{@code null} value
+     * @param nullAction action to be run if the value is {@code null}
+     * @param <T> type of the value
+     *
+     * @throws NullPointerException if {@code action} or {@code nullAction} is {@code null}
+     */
+    @SuppressWarnings("Contract") // Lombok's annotation is treated incorrectly
+    @Contract("_, null, _ -> fail; _, _, null -> fail")
+    public <T> void _ifPresentOrElse(final @Nullable T value,
+                                     final @NonNull Consumer<@NotNull ? super T> action,
+                                     final @NonNull Runnable nullAction) {
+        if (value == null) nullAction.run();
+        else action.accept(value);
     }
 
     /**
@@ -166,25 +187,6 @@ public class NullSafetyExtensions {
     }
 
     /**
-     * Runs the corresponding action depending on whether the value is {@code null}.
-     *
-     * @param value value to be checked
-     * @param action action to be run on non-{@code null} value
-     * @param nullAction action to be run if value is {@code null}
-     * @param <T> type of the value
-     *
-     * @throws NullPointerException if {@code action} or {@code nullAction} is {@code null}
-     */
-    @SuppressWarnings("Contract") // Lombok's annotation is treated incorrectly
-    @Contract("_, null, _ -> fail; _, _, null -> fail")
-    public <T> void _ifPresentOrElse(final @Nullable T value,
-                                     final @NonNull Consumer<? super T> action,
-                                     final @NonNull Runnable nullAction) {
-        if (value == null) nullAction.run();
-        else action.accept(value);
-    }
-
-    /**
      * Converts the value into an {@link Optional optional}
      * returning {@link Optional#empty()} if the value is {@code null}.
      *
@@ -192,6 +194,7 @@ public class NullSafetyExtensions {
      * @param <T> type of the value
      * @return value wrapped into an {@link Optional}
      */
+    @Contract("null -> _; _ -> new")
     public <T> @NotNull Optional<T> _toOptional(final @Nullable T value) {
         return Optional.ofNullable(value);
     }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
@@ -127,7 +127,7 @@ public class NullSafetyExtensions {
      * @param value checked value
      * @param throwableSupplier supplier of a throwable used when the value is {@code null}
      * @param <T> type of the value
-     * @param <X> thrown typethrowable
+     * @param <X> thrown type throwable
      * @return {@code value} if it is not {@code null}
      *
      * @throws X if {@code value} is null

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensions.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -100,7 +101,7 @@ public class NullSafetyExtensions {
     @SuppressWarnings("Contract") // Lombok's annotation is treated incorrectly
     @Contract("_, null -> fail; !null, _ -> _; null, _ -> null")
     public <T> @Nullable T _filter(final @Nullable T value,
-                                          final @NonNull Predicate<T> predicate) {
+                                   final @NonNull Predicate<T> predicate) {
         return value == null ? null : predicate.test(value) ? value : null;
     }
 
@@ -128,6 +129,7 @@ public class NullSafetyExtensions {
      * @param <T> type of the value
      * @param <X> thrown typethrowable
      * @return {@code value} if it is not {@code null}
+     *
      * @throws X if {@code value} is null
      * @throws NullPointerException if {@code throwableSupplier} or it supplies {@code null}
      */
@@ -161,6 +163,25 @@ public class NullSafetyExtensions {
      */
     public <T> @NotNull Stream<@Nullable T> _streamOfNullable(final @Nullable T value) {
         return Stream.of(value);
+    }
+
+    /**
+     * Runs the corresponding action depending on whether the value is {@code null}.
+     *
+     * @param value value to be checked
+     * @param action action to be run on non-{@code null} value
+     * @param nullAction action to be run if value is {@code null}
+     * @param <T> type of the value
+     *
+     * @throws NullPointerException if {@code action} or {@code nullAction} is {@code null}
+     */
+    @SuppressWarnings("Contract") // Lombok's annotation is treated incorrectly
+    @Contract("_, null, _ -> fail; _, _, null -> fail")
+    public <T> void _ifPresentOrElse(final @Nullable T value,
+                                     final @NonNull Consumer<? super T> action,
+                                     final @NonNull Runnable nullAction) {
+        if (value == null) nullAction.run();
+        else action.accept(value);
     }
 
     /**

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/extension/LegacyOptionalExtensionsTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/extension/LegacyOptionalExtensionsTest.java
@@ -1,0 +1,71 @@
+package ru.progrm_jarvis.javacommons.object.extension;
+
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtensionMethod(LegacyOptionalExtensions.class)
+class LegacyOptionalExtensionsTest {
+
+    private static final @NotNull String @NotNull [] EMPTY_STRING_ARRAY = {};
+
+    @Test
+    void ifPresentOrElse_onPresent() {
+        @SuppressWarnings("unchecked") final Consumer<String> action = mock(Consumer.class);
+        Optional.of("oh, hello").ifPresentOrElse(action, Assertions::fail);
+        verify(action).accept("oh, hello");
+    }
+
+    @Test
+    void ifPresentOrElse_onEmpty() {
+        val emptyAction = mock(Runnable.class);
+        Optional.empty().ifPresentOrElse(value -> fail(), emptyAction);
+        verify(emptyAction).run();
+    }
+
+    @Test
+    void ifPresentOrElse_onNullLambdas() {
+        assertThrows(NullPointerException.class, () -> Optional.of("something").ifPresentOrElse(null, () -> {}));
+        assertDoesNotThrow(() -> Optional.of("something").ifPresentOrElse(value -> {}, null));
+        assertThrows(NullPointerException.class, () -> Optional.empty().ifPresentOrElse(value -> {}, null));
+        assertDoesNotThrow(() -> Optional.empty().ifPresentOrElse(null, () -> {}));
+    }
+
+    @Test
+    void or() {
+        assertEquals(Optional.of("foo"), Optional.of("foo").or(() -> Optional.of("bar")));
+        assertEquals(Optional.of("foo"), Optional.of("foo").or(Optional::empty));
+        assertEquals(Optional.of("foo"), Optional.of("foo").or(() -> null));
+        assertEquals(Optional.of("baz"), Optional.empty().or(() -> Optional.of("baz")));
+        assertEquals(Optional.empty(), Optional.empty().or(Optional::empty));
+        assertEquals(null, Optional.empty().or(() -> null));
+    }
+
+    @Test
+    void or_throwsNPEonNullLambda() {
+        assertThrows(NullPointerException.class, () -> Optional.of("some value").or(null));
+        assertThrows(NullPointerException.class, () -> Optional.empty().or(null));
+    }
+
+    @Test
+    void stream() {
+        assertArrayEquals(new String[]{"wow"}, Optional.of("wow").stream().toArray(String[]::new));
+        assertArrayEquals(EMPTY_STRING_ARRAY, Optional.empty().stream().toArray(String[]::new));
+    }
+
+    @Test
+    void orElseThrow() {
+        assertDoesNotThrow(() -> Optional.of("wow").orElseThrow());
+        assertThrows(NoSuchElementException.class, () -> Optional.empty().orElseThrow());
+    }
+}

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensionsTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/extension/NullSafetyExtensionsTest.java
@@ -3,13 +3,17 @@ package ru.progrm_jarvis.javacommons.object.extension;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.experimental.ExtensionMethod;
+import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtensionMethod(NullSafetyExtensions.class)
 class NullSafetyExtensionsTest {
@@ -126,6 +130,27 @@ class NullSafetyExtensionsTest {
     void _streamOfNullable() {
         assertArrayEquals(new String[]{"value"}, "value"._streamOfNullable().toArray(String[]::new));
         assertArrayEquals(new String[]{null}, ((String) null)._streamOfNullable().toArray(String[]::new));
+    }
+
+    @Test
+    void _ifPresentOrElse_onNotNull() {
+        @SuppressWarnings("unchecked") final Consumer<String> action = mock(Consumer.class);
+        "value"._ifPresentOrElse(action, Assertions::fail);
+        verify(action).accept("value");
+    }
+
+    @Test
+    void _ifPresentOrElse_onNull() {
+        val nullAction = mock(Runnable.class);
+        ((String) null)._ifPresentOrElse(value -> fail(), nullAction);
+        verify(nullAction).run();
+    }
+
+    @Test
+    void _ifPresentOrElse_throwsNPEOnNullLambdaValue() {
+        assertThrows(NullPointerException.class, () -> ((String) null)._ifPresentOrElse(null, () -> {}));
+        assertThrows(NullPointerException.class, () -> ((String) null)._ifPresentOrElse(value -> {}, null));
+        assertThrows(NullPointerException.class, () -> ((String) null)._ifPresentOrElse(null, null));
     }
 
     @Test

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/NumberUtilTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/NumberUtilTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import ru.progrm_jarvis.javacommons.primitive.NumberUtil;
 
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,21 +19,17 @@ class NumberUtilTest {
     private static final long RANDOM_NUMBERS = 4096;
 
     static @NotNull Stream<@NotNull Arguments> intsWithRadixes() {
-        @SuppressWarnings("SharedThreadLocalRandom") val random = ThreadLocalRandom.current();
-        return IntStream.generate(() -> random.nextInt() + random.nextInt() /* twice to allow negative numbers */)
-                .limit(RANDOM_NUMBERS)
+        return ThreadLocalRandom.current().ints().limit(RANDOM_NUMBERS)
                 .mapToObj(number -> {
-                    val radix = random.nextInt(Character.MIN_RADIX, Character.MAX_RADIX + 1);
+                    val radix = ThreadLocalRandom.current().nextInt(Character.MIN_RADIX, Character.MAX_RADIX + 1);
                     return Arguments.of(number, Integer.toString(number, radix), radix);
                 });
     }
 
     static @NotNull Stream<@NotNull Arguments> longsWithRadixes() {
-        @SuppressWarnings("SharedThreadLocalRandom") val random = ThreadLocalRandom.current();
-        return LongStream.generate(() -> random.nextInt() + random.nextInt() /* twice to allow negative numbers */)
-                .limit(RANDOM_NUMBERS)
+        return ThreadLocalRandom.current().longs().limit(RANDOM_NUMBERS)
                 .mapToObj(number -> {
-                    val radix = random.nextInt(Character.MIN_RADIX, Character.MAX_RADIX + 1);
+                    val radix = ThreadLocalRandom.current().nextInt(Character.MIN_RADIX, Character.MAX_RADIX + 1);
                     return Arguments.of(number, Long.toString(number, radix), radix);
                 });
     }


### PR DESCRIPTION
# Description

This adds `LegacyOptionalExtensions` to allow usage of new methods of `Optional` on older Java versions.

This also adds `_ifPresentOrElse` method to `NullSafetyExtensions`, adds missing contracts to it.