### PR TITLE
Add ClassUtil#toNonPrimitive(Class<?>)

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/ClassUtil.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/ClassUtil.java
@@ -122,13 +122,26 @@ public class ClassUtil {
      *
      * @throws IllegalArgumentException if the given class is not primitive
      */
-    public @NotNull Class<?> toPrimitiveWrapper(@NotNull /* hot spot */ final Class<?> primitiveClass) {
+    public @NotNull Class<?> toPrimitiveWrapper(final @NotNull /* hot spot */ Class<?> primitiveClass) {
         final int primitiveClassIndex;
         if ((primitiveClassIndex = Arrays.binarySearch(
                 SORTED_PRIMITIVE_CLASSES, primitiveClass, CLASS_HASH_CODE_COMPARATOR
         )) < 0) throw new IllegalArgumentException("Given class is not primitive");
 
         return PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex];
+    }
+
+    /**
+     * Either returns a primitive-wrapper class for the given one if it is primitive or the provided class otherwise.
+     *
+     * @param originalClass class whose wrapper should be returned on demand
+     * @return primitive-wrapper class for the given class if it is primitive or the provided class otherwise
+     */
+    public @NotNull Class<?> toNonPrimitive(final @NotNull /* hot spot */ Class<?> originalClass) {
+        final int primitiveClassIndex;
+        return (primitiveClassIndex = Arrays.binarySearch(
+                SORTED_PRIMITIVE_CLASSES, originalClass, CLASS_HASH_CODE_COMPARATOR
+        )) < 0 ? originalClass : PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex];
     }
 
     /**

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/ClassUtilTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/ClassUtilTest.java
@@ -18,29 +18,40 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class ClassUtilTest {
 
-    protected static Stream<Class<?>> primitiveClassesStream() {
+    protected static @NotNull Stream<@NotNull Class<?>> primitiveClasses() {
         return Stream.of(
                 boolean.class, byte.class, char.class, short.class,
                 int.class, long.class, float.class, double.class
         );
     }
 
-    protected static Stream<Class<?>> primitiveWrapperClassesStream() {
+    protected static @NotNull Stream<@NotNull Class<?>> primitiveWrapperClasses() {
         return Stream.of(
                 Boolean.class, Byte.class, Character.class, Short.class,
                 Integer.class, Long.class, Float.class, Double.class
         );
     }
 
-    protected static Stream<Arguments> providePrimitives() {
-        return primitiveClassesStream().map(Arguments::arguments);
+    protected static @NotNull Stream<@NotNull Arguments> providePrimitives() {
+        return primitiveClasses().map(Arguments::arguments);
     }
 
-    protected static Stream<Arguments> providePrimitiveWrappers() {
-        return primitiveWrapperClassesStream().map(Arguments::arguments);
+    protected static @NotNull Stream<@NotNull Arguments> providePrimitiveWrappers() {
+        return primitiveWrapperClasses().map(Arguments::arguments);
     }
 
-    protected static Stream<Arguments> provideNonPrimitiveOrWrappers() {
+    protected static @NotNull Stream<@NotNull Class<?>> nonPrimitiveNonWrapperClasses() {
+        return Stream.of(
+                Object.class, String.class,
+                BigInteger.class, BigDecimal.class, BitSet.class,
+                ClassUtilTest.class,
+                List.class, ArrayList.class,
+                Annotation.class,
+                Override.class
+        );
+    }
+
+    protected static @NotNull Stream<@NotNull Arguments> provideNonPrimitiveOrWrappers() {
         return Stream.of(
                 arguments(Object.class),
                 arguments(String.class),
@@ -51,7 +62,7 @@ class ClassUtilTest {
         );
     }
 
-    protected static Stream<Arguments> providePrimitivesToPrimitiveWrappers() {
+    protected static @NotNull Stream<@NotNull Arguments> providePrimitivesToPrimitiveWrappers() {
         return Stream.of(
                 arguments(boolean.class, Boolean.class),
                 arguments(byte.class, Byte.class),
@@ -64,33 +75,35 @@ class ClassUtilTest {
         );
     }
 
-    protected static Stream<Arguments> provideClassesToNonPrimitive() {
+    protected static @NotNull Stream<@NotNull Arguments> provideClassesToNonPrimitive() {
         return Stream.concat(
                 providePrimitivesToPrimitiveWrappers(),
-                Stream.of(Object.class, String.class, List.class, ArrayList.class, Annotation.class, Override.class)
-                        .map(clazz -> arguments(clazz, clazz))
+                Stream.concat(
+                        primitiveWrapperClasses(),
+                        nonPrimitiveNonWrapperClasses()
+                ).map(clazz -> arguments(clazz, clazz))
         );
     }
 
-    protected static Stream<Arguments> provideDifferentPrimitivePairs() {
-        return primitiveClassesStream()
-                .flatMap(primitive -> primitiveClassesStream()
+    protected static @NotNull Stream<@NotNull Arguments> provideDifferentPrimitivePairs() {
+        return primitiveClasses()
+                .flatMap(primitive -> primitiveClasses()
                         .flatMap(otherPrimitive -> primitive == otherPrimitive
                                 ? Stream.empty() : Stream.of(arguments(primitive, otherPrimitive))
                         )
                 );
     }
 
-    protected static Stream<Arguments> provideDifferentPrimitiveWrapperPairs() {
-        return primitiveWrapperClassesStream()
-                .flatMap(primitiveWrapper -> primitiveWrapperClassesStream()
+    protected static @NotNull Stream<@NotNull Arguments> provideDifferentPrimitiveWrapperPairs() {
+        return primitiveWrapperClasses()
+                .flatMap(primitiveWrapper -> primitiveWrapperClasses()
                         .flatMap(otherPrimitive -> primitiveWrapper == otherPrimitive
                                 ? Stream.empty() : Stream.of(arguments(primitiveWrapper, otherPrimitive))
                         )
                 );
     }
 
-    protected static Stream<Arguments> provideOneSideIntegrableNonPrimitivePairs() {
+    protected static @NotNull Stream<@NotNull Arguments> provideOneSideIntegrableNonPrimitivePairs() {
         return Stream.of(
                 arguments(String.class, CharSequence.class),
                 arguments(StringBuilder.class, CharSequence.class),
@@ -103,7 +116,7 @@ class ClassUtilTest {
         );
     }
 
-    protected static Stream<Arguments> provideUnassignablePairs() {
+    protected static @NotNull Stream<@NotNull Arguments> provideUnassignablePairs() {
         return Stream.of(
                 arguments(String.class, ArrayList.class),
                 arguments(String.class, HashSet.class),

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/ClassUtilTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/ClassUtilTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import ru.progrm_jarvis.javacommons.classloading.ClassUtil;
 
+import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
@@ -60,6 +61,14 @@ class ClassUtilTest {
                 arguments(long.class, Long.class),
                 arguments(float.class, Float.class),
                 arguments(double.class, Double.class)
+        );
+    }
+
+    protected static Stream<Arguments> provideClassesToNonPrimitive() {
+        return Stream.concat(
+                providePrimitivesToPrimitiveWrappers(),
+                Stream.of(Object.class, String.class, List.class, ArrayList.class, Annotation.class, Override.class)
+                        .map(clazz -> arguments(clazz, clazz))
         );
     }
 
@@ -158,6 +167,12 @@ class ClassUtilTest {
     @MethodSource("provideNonPrimitiveOrWrappers")
     void testToPrimitiveWithNonPrimitiveOrWrapperClasses(final @NotNull Class<?> nonPrimitiveOrWrapper) {
         assertThrows(IllegalArgumentException.class, () -> ClassUtil.toPrimitive(nonPrimitiveOrWrapper));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideClassesToNonPrimitive")
+    void testToNonPrimitive(final @NotNull Class<?> original, final @NotNull Class<?> nonPrimitive) {
+        assertSame(nonPrimitive, ClassUtil.toNonPrimitive(original));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# Description

This adds `ClassUtil#toNonPrimitive(Class<?>)` which is a non-throwing alternative to `ClassUtil#toPrimitiveWrapper(Class<?>)`.