### PR TITLE
Add `CompletableFutures`

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
@@ -1,0 +1,38 @@
+package ru.progrm_jarvis.javacommons.util.concurrent;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.object.Pair;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Utilities related to {@link CompletableFuture completable futures}.
+ */
+@UtilityClass
+public class CompletableFutures {
+
+    /**
+     * Returns the completable future whose result is a pair of the provided future's results if both of them complete.
+     * The future completes exceptionally if any of the given futures completes exceptionally.
+     *
+     * @param first first futures
+     * @param second second futures
+     * @param <F> the result type of the first future
+     * @param <S> the result type of the second future
+     * @return a new completable future that is completed when both of the given futures complete
+     *
+     * @see CompletableFuture#allOf(CompletableFuture[]) var-arg untyped equivalent
+     */
+    public @NotNull <F, S> CompletableFuture<@NotNull Pair<F, S>> bothOf(final @NonNull CompletableFuture<F> first,
+                                                                         final @NonNull CompletableFuture<S> second) {
+        val firstResult = new AtomicReference<F>();
+        val secondResult = new AtomicReference<S>();
+
+        return CompletableFuture.allOf(first.thenAccept(firstResult::set), second.thenAccept(secondResult::set))
+                .thenApply(unused -> Pair.of(firstResult.get(), secondResult.get()));
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
@@ -2,7 +2,7 @@ package ru.progrm_jarvis.javacommons.util.concurrent;
 
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import lombok.val;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import ru.progrm_jarvis.javacommons.object.Pair;
 
@@ -19,20 +19,18 @@ public class CompletableFutures {
      * Returns the completable future whose result is a pair of the provided future's results if both of them complete.
      * The future completes exceptionally if any of the given futures completes exceptionally.
      *
-     * @param first first futures
-     * @param second second futures
+     * @param first first future
+     * @param second second future
      * @param <F> the result type of the first future
      * @param <S> the result type of the second future
      * @return a new completable future that is completed when both of the given futures complete
      *
      * @see CompletableFuture#allOf(CompletableFuture[]) var-arg untyped equivalent
      */
-    public @NotNull <F, S> CompletableFuture<@NotNull Pair<F, S>> bothOf(final @NonNull CompletableFuture<F> first,
-                                                                         final @NonNull CompletableFuture<S> second) {
-        val firstResult = new AtomicReference<F>();
-        val secondResult = new AtomicReference<S>();
-
-        return CompletableFuture.allOf(first.thenAccept(firstResult::set), second.thenAccept(secondResult::set))
-                .thenApply(unused -> Pair.of(firstResult.get(), secondResult.get()));
+    public @NotNull <F, S> CompletableFuture<@NotNull Pair<F, S>> bothOf(
+            final @NonNull CompletableFuture<F> first,
+            @SuppressWarnings("TypeMayBeWeakened" /* for API stability */) final @NonNull CompletableFuture<S> second
+    ) {
+        return first.thenCombine(second, Pair::of);
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFutures.java
@@ -4,16 +4,37 @@ import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.annotation.Any;
 import ru.progrm_jarvis.javacommons.object.Pair;
+import ru.progrm_jarvis.javacommons.object.Result;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Utilities related to {@link CompletableFuture completable futures}.
  */
 @UtilityClass
 public class CompletableFutures {
+
+    /**
+     * Creates a completable future which instantly
+     * {@link CompletableFuture#completeExceptionally(Throwable) completes exceptionally}
+     * with the provided throwable.
+     *
+     * @param throwable throwable with which the future completes exceptionally
+     * @param <T> the result type of the future
+     * @return the exceptionally completed future
+     *
+     * @throws NullPointerException if {@code throwable} is {@code null}
+     */
+    public static <@Any T> @NotNull CompletableFuture<T> exceptionallyCompletedFuture(
+            final @NonNull Throwable throwable
+    ) {
+        final CompletableFuture<T> future;
+        (future = new CompletableFuture<>()).completeExceptionally(throwable);
+
+        return future;
+    }
 
     /**
      * Returns the completable future whose result is a pair of the provided future's results if both of them complete.
@@ -25,6 +46,8 @@ public class CompletableFutures {
      * @param <S> the result type of the second future
      * @return a new completable future that is completed when both of the given futures complete
      *
+     * @throws NullPointerException if {@code first} is {@code null}
+     * @throws NullPointerException if {@code second} is {@code null}
      * @see CompletableFuture#allOf(CompletableFuture[]) var-arg untyped equivalent
      */
     public @NotNull <F, S> CompletableFuture<@NotNull Pair<F, S>> bothOf(
@@ -32,5 +55,48 @@ public class CompletableFutures {
             @SuppressWarnings("TypeMayBeWeakened" /* for API stability */) final @NonNull CompletableFuture<S> second
     ) {
         return first.thenCombine(second, Pair::of);
+    }
+
+    /**
+     * Returns the completable future whose result is the result of either the first or the second future
+     * wrapped in either a {@link Result#success(Object) successful result}
+     * or an {@link Result#error(Object) error result} respectively.
+     * The future completes exceptionally if the first completing future completes exceptionally.
+     *
+     * @param successFuture first futures
+     * @param errorFuture second futures
+     * @param <F> the result type of the first future
+     * @param <S> the result type of the second future
+     * @return a new completable future that is completed when either of the given futures completes
+     *
+     * @throws NullPointerException if {@code successFuture} is {@code null}
+     * @throws NullPointerException if {@code errorFuture} is {@code null}
+     * @see CompletableFuture#anyOf(CompletableFuture[]) var-arg untyped equivalent
+     */
+    public @NotNull <F, S> CompletableFuture<@NotNull Result<F, S>> eitherOf(
+            final @NonNull CompletableFuture<F> successFuture,
+            final @NonNull CompletableFuture<S> errorFuture
+    ) {
+        // the `success` and `error` results don't overlap thus it is safe to perform the cast
+        return uncheckedCompletableFutureCast(CompletableFuture.anyOf(
+                successFuture.thenApply(Result::success),
+                errorFuture.thenApply(Result::error)
+        ));
+    }
+
+    /**
+     * Casts the given completable future into the specific one.
+     *
+     * @param future raw-typed completable future
+     * @param <T> exact wanted type of completable future
+     * @return the provided completable future with its type cast to the specific one
+     *
+     * @apiNote this is effectively no-op
+     */
+    // note: no nullability annotations are present on parameter and return type as cast of `null` is also safe
+    @Contract("_ -> param1")
+    @SuppressWarnings("unchecked")
+    private static <T> CompletableFuture<T> uncheckedCompletableFutureCast(final CompletableFuture<?> future) {
+        return (CompletableFuture<T>) future;
     }
 }

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFuturesTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/util/concurrent/CompletableFuturesTest.java
@@ -1,0 +1,124 @@
+package ru.progrm_jarvis.javacommons.util.concurrent;
+
+import lombok.val;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import ru.progrm_jarvis.javacommons.object.Pair;
+import ru.progrm_jarvis.javacommons.object.Result;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class CompletableFuturesTest {
+
+    static @NotNull Stream<@NotNull Throwable> throwableStream() {
+        return Stream.of(
+                new Throwable("Great"),
+                new AssertionError("Amazing"),
+                new RuntimeException("Nice"),
+                new Error("Just right")
+        );
+    }
+
+    static @NotNull Stream<@NotNull Arguments> provideThrowables() {
+        return throwableStream().map(Arguments::of);
+    }
+
+    static @NotNull Stream<@NotNull Arguments> provideCompletableFuturesBothNotExceptional() {
+        return Stream.of(
+                arguments(completedFuture("A"), completedFuture(123), Pair.of("A", 123))
+        );
+    }
+
+    static @NotNull Stream<@NotNull Arguments> provideCompletableFuturesAtLeastOneExceptional() {
+        return throwableStream()
+                .flatMap(throwable -> Stream.of(
+                        arguments(
+                                completedFuture("First"),
+                                CompletableFutures.exceptionallyCompletedFuture(throwable),
+                                throwable
+                        ),
+                        arguments(
+                                CompletableFutures.exceptionallyCompletedFuture(throwable),
+                                completedFuture("Second"),
+                                throwable
+                        ),
+                        arguments(
+                                CompletableFutures.exceptionallyCompletedFuture(throwable),
+                                CompletableFutures.exceptionallyCompletedFuture(throwable),
+                                throwable
+                        )
+                ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideThrowables")
+    void exceptionallyCompletedFuture(final @NotNull Throwable throwable) {
+        val future = CompletableFutures.exceptionallyCompletedFuture(throwable);
+
+        assertTrue(future.isCompletedExceptionally()); // thus no need for test timeout
+        try {
+            future.join();
+        } catch (final Throwable thrown) {
+            assertSame(throwable, thrown.getCause());
+            return; // don't fail
+        }
+
+        fail("The future completed un-exceptionally");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCompletableFuturesBothNotExceptional")
+    <F, S> void ofBoth(final @NotNull CompletableFuture<F> first,
+                       final @NotNull CompletableFuture<S> second,
+                       final @NotNull Pair<F, S> result) {
+        val future = CompletableFutures.bothOf(first, second);
+
+        assertTrue(future.isDone()); // provider guarantee
+
+        assertEquals(result, future.join());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCompletableFuturesAtLeastOneExceptional")
+    <F, S> void ofBothExceptionally(final @NotNull CompletableFuture<F> first,
+                                    final @NotNull CompletableFuture<S> second,
+                                    final @NotNull Throwable throwable) {
+        val future = CompletableFutures.bothOf(first, second);
+
+        assertTrue(future.isCompletedExceptionally());
+
+        try {
+            future.join();
+        } catch (final Throwable thrown) {
+            assertSame(throwable, thrown.getCause());
+            return; // don't fail
+        }
+
+        fail("The future completed un-exceptionally");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCompletableFuturesBothNotExceptional")
+    <F, S> void ofEither(final @NotNull CompletableFuture<F> first,
+                         final @NotNull CompletableFuture<S> second,
+                         final @NotNull Pair<F, S> resultVariants) {
+        val future = CompletableFutures.eitherOf(first, second);
+
+        assertTrue(future.isDone()); // provider guarantee
+
+        assertThat(future.join(),
+                either(equalTo(Result.<F, S>success(resultVariants.getFirst())))
+                        .or(equalTo(Result.<F, S>error(resultVariants.getSecond())))
+        );
+    }
+}


### PR DESCRIPTION
# Description

This adds `CompletableFutures` with `bothOf(..)` method being a generic non-vararg analog of `CompletableFuture#allOf(..)`.

# Contributors

A typo was discovered in the code by @zabelovq before the commit.