### PR TITLE
Enable partial support for Java 11 features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <!-- Testing -->
         <version.junit>5.7.2</version.junit>
         <version.junit.platform>1.7.2</version.junit.platform>


### PR DESCRIPTION
# Description

This enables usage of Java 11 source components such as `VarHandle`s while still compiling to Java 8.