### PR TITLE
Add generics to `ClassUtil` where applicable.

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/JavaCommons.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/JavaCommons.java
@@ -1,0 +1,10 @@
+package ru.progrm_jarvis.javacommons;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utilities mostly used by <b>java-commons</b> internals.
+ */
+@UtilityClass
+public class JavaCommons {
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/ClassUtil.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/ClassUtil.java
@@ -10,6 +10,8 @@ import java.util.Comparator;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static ru.progrm_jarvis.javacommons.unchecked.UncheckedCasts.uncheckedClassCast;
+
 /**
  * Utility for class-related stuff.
  */
@@ -121,47 +123,52 @@ public class ClassUtil {
      * Gets a primitive-wrapper class for the given primitive class.
      *
      * @param primitiveClass primitive class whose wrapper is needed
+     * @param <T> specific class type
      * @return primitive-wrapper class for the given primitive class
      *
      * @throws IllegalArgumentException if the given class is not primitive
      */
-    public @NotNull Class<?> toPrimitiveWrapper(final @NotNull /* hot spot */ Class<?> primitiveClass) {
+    public <T> @NotNull Class<? extends T> toPrimitiveWrapper(final @NotNull Class<? super T> primitiveClass) {
         final int primitiveClassIndex;
         if ((primitiveClassIndex = Arrays.binarySearch(
                 SORTED_PRIMITIVE_CLASSES, primitiveClass, CLASS_HASH_CODE_COMPARATOR
         )) < 0) throw new IllegalArgumentException("Given class is not primitive");
 
-        return PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex];
+        return uncheckedClassCast(PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex]);
     }
 
     /**
      * Either returns a primitive-wrapper class for the given one if it is primitive or the provided class otherwise.
      *
      * @param originalClass class whose wrapper should be returned on demand
+     * @param <T> specific class type
      * @return primitive-wrapper class for the given class if it is primitive or the provided class otherwise
      */
-    public @NotNull Class<?> toNonPrimitive(final @NotNull /* hot spot */ Class<?> originalClass) {
+    public <T> @NotNull Class<? extends T> toNonPrimitive(final @NotNull Class<? super T> originalClass) {
         final int primitiveClassIndex;
-        return (primitiveClassIndex = Arrays.binarySearch(
-                SORTED_PRIMITIVE_CLASSES, originalClass, CLASS_HASH_CODE_COMPARATOR
-        )) < 0 ? originalClass : PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex];
+        return uncheckedClassCast(
+                (primitiveClassIndex = Arrays.binarySearch(
+                        SORTED_PRIMITIVE_CLASSES, originalClass, CLASS_HASH_CODE_COMPARATOR
+                )) < 0 ? originalClass : PRIMITIVE_WRAPPER_CLASSES_SORTED_BY_PRIMITIVE_CLASSES[primitiveClassIndex]
+        );
     }
 
     /**
      * Gets a primitive class for the given primitive-wrapper class.
      *
      * @param primitiveWrapperClass primitive-wrapper class whose wrapper is needed
+     * @param <T> specific class type
      * @return primitive class for the given primitive-wrapper class
      *
      * @throws IllegalArgumentException if the given class is not a primitive-wrapper
      */
-    public Class<?> toPrimitive(@NotNull /* hot spot */ final Class<?> primitiveWrapperClass) {
+    public <T> @NotNull Class<? extends T> toPrimitive(final @NotNull Class<? super T> primitiveWrapperClass) {
         final int primitiveClassIndex;
         if ((primitiveClassIndex = Arrays.binarySearch(
                 SORTED_PRIMITIVE_WRAPPER_CLASSES, primitiveWrapperClass, CLASS_HASH_CODE_COMPARATOR
         )) < 0) throw new IllegalArgumentException("Given class is not a primitive-wrapper");
 
-        return PRIMITIVE_CLASSES_SORTED_BY_PRIMITIVE_WRAPPER_CLASSES[primitiveClassIndex];
+        return uncheckedClassCast(PRIMITIVE_CLASSES_SORTED_BY_PRIMITIVE_WRAPPER_CLASSES[primitiveClassIndex]);
     }
 
     /**
@@ -172,15 +179,16 @@ public class ClassUtil {
      *
      * @param original original type which should be integrated to the target type
      * @param target target type to which the original type should be integrated
+     * @param <T> specific class type
      * @return result of type integration, my be the same as original type
      *
      * @throws IllegalArgumentException if original type cannot be integrated to the target type
      */
-    public Class<?> integrateType(final @NotNull /* hot spot */ Class<?> original,
-                                  final @NotNull /* hot spot */ Class<?> target) {
+    public <T> Class<? extends T> integrateType(final @NotNull Class<? super T> original,
+                                                final @NotNull Class<? super T> target) {
         // As `Class#isAssignableFrom()` is an intrinsic candidate
         // there is no need for simple `==` check which is probably included in it
-        if (target.isAssignableFrom(original)) return original;
+        if (target.isAssignableFrom(original)) return uncheckedClassCast(original);
 
         if(!original.isPrimitive()) throw new IllegalArgumentException(
                 "Original type " + original + " cannot be integrated with the target type " + target
@@ -193,7 +201,7 @@ public class ClassUtil {
                         + " cannot be integrated with target type " + target
         );
 
-        return wrapper;
+        return uncheckedClassCast(wrapper);
     }
 
     /**

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/extension/LegacyClassExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/classloading/extension/LegacyClassExtensions.java
@@ -57,14 +57,13 @@ public class LegacyClassExtensions {
      *
      * @param type raw-typed array-class object
      * @param <T> exact wanted type of array-class object
-     * @return the provided array-class object with its type case to the specific one
+     * @return the provided array-class object with its type cast to the specific one
      *
      * @apiNote this is effectively no-op
      */
-    // note: no nullability annotations are present on parameter and return type as cast of `null` is also safe
     @Contract("_ -> param1")
     @SuppressWarnings("unchecked")
-    private <T> Class<T[]> uncheckedArrayClassCast(final Class<?> type) {
+    public <T> Class<T[]> uncheckedArrayClassCast(final Class<?> type) {
         return (Class<T[]>) type;
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/CachingGeneratingDelegateFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/CachingGeneratingDelegateFactory.java
@@ -64,7 +64,7 @@ public abstract class CachingGeneratingDelegateFactory implements DelegateFactor
      *
      * @param type raw-typed delegate wrapper factory
      * @param <T> exact wanted type of delegate wrapper factory
-     * @return the provided delegate wrapper factory with its type case to the specific one
+     * @return the provided delegate wrapper factory with its type cast to the specific one
      *
      * @apiNote this is effectively no-op
      */

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/invoke/FullAccessLookupFactories.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/invoke/FullAccessLookupFactories.java
@@ -144,7 +144,7 @@ public class FullAccessLookupFactories {
      *
      * @param type raw-typed constructor array
      * @param <T> exact wanted type of constructor array
-     * @return the provided constructor array with its type case to the specific one
+     * @return the provided constructor array with its type cast to the specific one
      *
      * @apiNote this is effectively no-op
      */

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/lazy/Lazy.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/lazy/Lazy.java
@@ -148,7 +148,6 @@ public interface Lazy<T> extends Supplier<T> {
      *
      * @param <T> type of wrapped value
      */
-    @Data
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     final class SimpleLazy<T> implements Lazy<T> {

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/lazy/Lazy.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/lazy/Lazy.java
@@ -83,7 +83,7 @@ public interface Lazy<T> extends Supplier<T> {
      *
      * @apiNote might be thread-unsafe
      */
-    static <T> Lazy<T> create(final @NonNull Supplier<T> valueSupplier) {
+    static <T> Lazy<T> create(final @NonNull Supplier<? extends T> valueSupplier) {
         return new SimpleLazy<>(valueSupplier);
     }
 
@@ -94,7 +94,7 @@ public interface Lazy<T> extends Supplier<T> {
      * @param <T> type of value wrapped
      * @return created lazy
      */
-    static <T> Lazy<T> createThreadSafe(final @NonNull Supplier<T> valueSupplier) {
+    static <T> Lazy<T> createThreadSafe(final @NonNull Supplier<? extends T> valueSupplier) {
         //noinspection ZeroLengthArrayAllocation: mutex object
         return new DoubleCheckedLazy<>(new Object[0], valueSupplier);
     }
@@ -110,7 +110,7 @@ public interface Lazy<T> extends Supplier<T> {
      * @apiNote weak lazy stores the value wrapped in weak reference and so it may be GCed
      * and so the new one might be recomputed using the value supplier
      */
-    static <T> Lazy<@NotNull T> createWeak(final @NonNull Supplier<@NotNull T> valueSupplier) {
+    static <T> Lazy<@NotNull T> createWeak(final @NonNull Supplier<@NotNull ? extends T> valueSupplier) {
         return new SimpleWeakLazy<>(valueSupplier, ReferenceUtil.weakReferenceToNull());
     }
 
@@ -124,7 +124,7 @@ public interface Lazy<T> extends Supplier<T> {
      * @apiNote weak lazy stores the value wrapped in weak reference and so it may be GCed
      * and so the new one might be recomputed using the value supplier
      */
-    static <T> Lazy<T> createWeakThreadSafe(final @NonNull Supplier<T> valueSupplier) {
+    static <T> Lazy<T> createWeakThreadSafe(final @NonNull Supplier<? extends T> valueSupplier) {
         final ReadWriteLock lock;
         return new LockingWeakLazy<>(
                 (lock = new ReentrantReadWriteLock()).readLock(), lock.writeLock(),
@@ -139,7 +139,7 @@ public interface Lazy<T> extends Supplier<T> {
      * @param <T> type of value wrapped
      * @return created lazy
      */
-    static <T> Lazy<T> createThreadLocal(final @NonNull Supplier<T> valueSupplier) {
+    static <T> Lazy<T> createThreadLocal(final @NonNull Supplier<? extends T> valueSupplier) {
         return new ThreadLocalLazy<>(valueSupplier, ThreadLocal.withInitial(() -> ThreadLocalLazy.UNSET_VALUE));
     }
 
@@ -155,14 +155,14 @@ public interface Lazy<T> extends Supplier<T> {
         /**
          * Supplier used for creation of the value
          */
-        @Nullable Supplier<@Nullable T> valueSupplier;
+        @Nullable Supplier<? extends T> valueSupplier;
 
         /**
          * The value stored
          */
         T value;
 
-        private SimpleLazy(final @NotNull Supplier<T> valueSupplier) {
+        private SimpleLazy(final @NotNull Supplier<? extends T> valueSupplier) {
             this.valueSupplier = valueSupplier;
         }
 
@@ -209,7 +209,7 @@ public interface Lazy<T> extends Supplier<T> {
         /**
          * Supplier used for creation of the value
          */
-        @Nullable volatile Supplier<T> valueSupplier;
+        @Nullable volatile Supplier<? extends T> valueSupplier;
 
         /**
          * The value stored
@@ -222,7 +222,7 @@ public interface Lazy<T> extends Supplier<T> {
          * @param mutex mutex to be used for synchronization
          * @param valueSupplier supplier used for creation of the value
          */
-        private DoubleCheckedLazy(final @NotNull Object mutex, final @NotNull Supplier<T> valueSupplier) {
+        private DoubleCheckedLazy(final @NotNull Object mutex, final @NotNull Supplier<? extends T> valueSupplier) {
             this.mutex = mutex;
             this.valueSupplier = valueSupplier;
         }
@@ -230,7 +230,7 @@ public interface Lazy<T> extends Supplier<T> {
         @Override
         public T get() {
             if (valueSupplier != null) synchronized (mutex) {
-                final Supplier<T> valueSupplier;
+                final Supplier<? extends T> valueSupplier;
                 if ((valueSupplier = this.valueSupplier) != null) {
                     val value = this.value = valueSupplier.get();
                     this.valueSupplier = null;
@@ -283,7 +283,7 @@ public interface Lazy<T> extends Supplier<T> {
         /**
          * Supplier used for creation of the value
          */
-        final @NotNull Supplier<@NotNull T> valueSupplier;
+        final @NotNull Supplier<@NotNull ? extends T> valueSupplier;
 
         /**
          * The value stored wrapped in {@link WeakReference}
@@ -339,7 +339,7 @@ public interface Lazy<T> extends Supplier<T> {
         /**
          * Supplier used for creation of the value
          */
-        @NotNull Supplier<T> valueSupplier;
+        @NotNull Supplier<? extends T> valueSupplier;
 
         /**
          * The value stored wrapped in {@link WeakReference}
@@ -417,7 +417,7 @@ public interface Lazy<T> extends Supplier<T> {
         /**
          * Supplier used for creation of the value
          */
-        @NotNull Supplier<T> valueSupplier;
+        @NotNull Supplier<? extends T> valueSupplier;
 
         /**
          * The value stored wrapped in {@link ThreadLocal}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/unchecked/UncheckedCasts.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/unchecked/UncheckedCasts.java
@@ -1,0 +1,29 @@
+package ru.progrm_jarvis.javacommons.unchecked;
+
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.Contract;
+
+/**
+ * Commonly used unchecked cast operations.
+ *
+ * @apiNote no nullability annotations are present on parameters and return types
+ * because casts of {@code null} are always safe
+ */
+@UtilityClass
+public class UncheckedCasts {
+
+    /**
+     * Casts the given class object into the specific one.
+     *
+     * @param type raw-typed class object
+     * @param <T> exact wanted type of class object
+     * @return the provided class object with its type cast to the specific one
+     *
+     * @apiNote this is effectively no-op
+     */
+    @Contract("_ -> param1")
+    @SuppressWarnings("unchecked")
+    public <T> Class<T> uncheckedClassCast(final Class<?> type) {
+        return (Class<T>) type;
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/TypeHints.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/TypeHints.java
@@ -1,11 +1,12 @@
 package ru.progrm_jarvis.javacommons.util;
 
 import lombok.experimental.UtilityClass;
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.*;
+
+import static ru.progrm_jarvis.javacommons.unchecked.UncheckedCasts.uncheckedClassCast;
 
 /**
  * Utilities related to special hacks around Java's types, especially generics.
@@ -24,22 +25,6 @@ public class TypeHints {
     @SuppressWarnings("unchecked")
     public <T> @NotNull Class<T> resolve(final @Nullable T... typeHint) {
         return uncheckedClassCast(typeHint.getClass().getComponentType());
-    }
-
-    /**
-     * Casts the given class object into the specific one.
-     *
-     * @param type raw-typed class object
-     * @param <T> exact wanted type of class object
-     * @return the provided class object with its type case to the specific one
-     *
-     * @apiNote this is effectively no-op
-     */
-    // note: no nullability annotations are present on parameter and return type as cast of `null` is also safe
-    @Contract("_ -> param1")
-    @SuppressWarnings("unchecked")
-    private <T> Class<T> uncheckedClassCast(final Class<?> type) {
-        return (Class<T>) type;
     }
 
     /**

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/stream/extension/LegacyCollectorExtensions.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/stream/extension/LegacyCollectorExtensions.java
@@ -70,7 +70,7 @@ public class LegacyCollectorExtensions {
      *
      * @param raw raw-types list
      * @param <T> exact wanted type of list elements
-     * @return the provided list with its type case to the specific one
+     * @return the provided list with its type cast to the specific one
      *
      * @apiNote this is effectively no-op
      */

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeConstructorWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeConstructorWrapper.java
@@ -159,7 +159,7 @@ public class InvokeConstructorWrapper<@NotNull T>
      *
      * @param type raw-typed constructor
      * @param <T> exact wanted type of constructor
-     * @return the provided constructor with its type case to the specific one
+     * @return the provided constructor with its type cast to the specific one
      *
      * @apiNote this is effectively no-op
      */

--- a/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/AsmTextModelFactory.java
+++ b/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/AsmTextModelFactory.java
@@ -20,6 +20,7 @@ import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.javacommons.lazy.Lazy;
 import ru.progrm_jarvis.javacommons.object.valuestorage.SimpleValueStorage;
 import ru.progrm_jarvis.javacommons.object.valuestorage.ValueStorage;
+import ru.progrm_jarvis.javacommons.unchecked.UncheckedCasts;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -32,6 +33,7 @@ import java.util.logging.Level;
 import static org.objectweb.asm.Opcodes.*;
 import static org.objectweb.asm.Type.*;
 import static ru.progrm_jarvis.javacommons.bytecode.asm.AsmUtil.*;
+import static ru.progrm_jarvis.javacommons.unchecked.UncheckedCasts.uncheckedClassCast;
 
 /**
  * Implementation of {@link TextModelFactory text model factory} which uses runtime class generation.
@@ -575,22 +577,6 @@ public final class AsmTextModelFactory<T, C extends AsmTextModelFactory.Configur
                         "Generated class " + className + " cannot be instantiated", x
                 );
             }
-        }
-
-        /**
-         * Casts the given class object into the specific one.
-         *
-         * @param type raw-typed class object
-         * @param <T> exact wanted type of class object
-         * @return the provided class object with its type cast to the specific one
-         *
-         * @apiNote this is effectively no-op
-         */
-        // note: no nullability annotations are present on parameter and return type as cast of `null` is also safe
-        @Contract("_ -> param1")
-        @SuppressWarnings("unchecked")
-        private static <T> Class<T> uncheckedClassCast(final Class<?> type) {
-            return (Class<T>) type;
         }
 
         /**


### PR DESCRIPTION
# Description

This adds missing PECS-friendly generics to `ClassUtil`.

This also cleans up some mess in `Lazy`.