### PR TITLE
Cache abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ As its dependencies PADLA uses:
 - Compiletime:
   - [Lombok](https://github.com/rzwitserloot/lombok) for generating boilerplate stuff
   - [Jetbrains Annotations](https://github.com/JetBrains/java-annotations) for documenting code logic
-- Runtime:
-  - [Caffeine](https://github.com/ben-manes/caffeine) for caching
 - Testing:
   - [Junit5](https://github.com/junit-team/junit5/) with related sub-tools for testing
   - [Hamcrest](https://github.com/hamcrest/JavaHamcrest) for more creating more readable tests
@@ -27,3 +25,5 @@ As its dependencies PADLA uses:
 - Additional (these are not inherited by default and are required only if using specific classes):
   - [ASM](https://gitlab.ow2.org/asm/asm) for runtime class generation (if using classes annotated with `@UsesBytecodeModification(CommonBytecodeLibrary.ASM)`)
   - [Javassist](https://github.com/jboss-javassist/javassist) for runtime class generation (if using classes annotated with `@UsesBytecodeModification(CommonBytecodeLibrary.JAVASSIST)`)
+- Optional (these are not required at all but allow some extra integrations and optimizations):
+  - [Caffeine](https://github.com/ben-manes/caffeine) for caching of internal components

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/Cache.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/Cache.java
@@ -1,0 +1,43 @@
+package ru.progrm_jarvis.javacommons.cache;
+
+import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+/**
+ * Simple cache interface.
+ * {@link #never() No-op implementation} (the one which never performs any caching) is considered correct.
+ *
+ * @param <K> type of cache keys
+ * @param <V> type of cached values
+ *
+ * @apiNote currently <b>java-commons</b> does not implement its own functional cache,
+ * it simply provides a universal interface and wrappers for known implementations
+ */
+@FunctionalInterface
+public interface Cache<K, V> {
+
+    /**
+     * Gets the value from the cache computing it on demand using the provided function.
+     *
+     * @param key key by which ti get the value from cache
+     * @param mappingFunction function used to create the value if there is no cached one
+     * @return the current value associated with the specified key
+     *
+     * @throws NullPointerException if {@code key} is {@code null}
+     * @throws NullPointerException if {@code mappingFunction} is {@code null}
+     */
+    V get(@NonNull K key, @NonNull Function<? super K, ? extends V> mappingFunction);
+
+    /**
+     * Creates a cache which actually never performs caching.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return cache which actually never performs caching
+     */
+    static @NotNull <K, V> Cache<K, V> never() {
+        return (key, mappingFunction) -> mappingFunction.apply(key);
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/CacheFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/CacheFactory.java
@@ -1,0 +1,74 @@
+package ru.progrm_jarvis.javacommons.cache;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory used for creation of generic {@link Cache caches}.
+ */
+public interface CacheFactory {
+
+    /**
+     * Creates a new cache whose keys will be stored {@link java.lang.ref.WeakReference weakly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return weak keys cache
+     */
+    <K, V> @NotNull Cache<K, V> weakKeysCache();
+
+    /**
+     * Creates a new cache whose values will be stored {@link java.lang.ref.WeakReference weakly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return weak values cache
+     */
+    <K, V> @NotNull Cache<K, V> weakValuesCache();
+
+    /**
+     * Creates a new cache whose values will be stored {@link java.lang.ref.SoftReference softly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return soft values cache
+     */
+    <K, V> @NotNull Cache<K, V> softValuesCache();
+
+    /**
+     * Creates a cache factory which always creates {@link Cache#never() no-op caches}.
+     *
+     * @return cache factory which always supplies {@link Cache#never() no-op caches}
+     */
+    static @NotNull CacheFactory never() {
+        return NeverCacheFactory.INSTANCE;
+    }
+
+    /**
+     * {@link CacheFactory} which always creates {@link Cache#never() no-op caches}.
+     */
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    final class NeverCacheFactory implements CacheFactory {
+
+        /**
+         * Singleton instance of this cache factory.
+         */
+        private static final @NotNull CacheFactory INSTANCE = new NeverCacheFactory();
+
+        @Override
+        public @NotNull <K, V> Cache<K, V> weakKeysCache() {
+            return Cache.never();
+        }
+
+        @Override
+        public <K, V> @NotNull Cache<K, V> weakValuesCache() {
+            return Cache.never();
+        }
+
+        @Override
+        public @NotNull <K, V> Cache<K, V> softValuesCache() {
+            return Cache.never();
+        }
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/Caches.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/Caches.java
@@ -1,0 +1,111 @@
+package ru.progrm_jarvis.javacommons.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.util.BlackHole;
+
+/**
+ * Utility for creating commonly used caches depending on runtime capabilities.
+ * If no cache is available then {@link Cache#never() no-op cache} is used.
+ */
+@UtilityClass
+public class Caches {
+
+    /**
+     * Factory used for creation of {@link Cache caches}.
+     * This will try to be the best implementation available
+     * but will fallback to {@link CacheFactory#never() no-op} if none is available.
+     */
+    private final @NotNull CacheFactory FACTORY;
+
+    static {
+        CacheFactory factory = null;
+
+        caffeineCache: {
+            try { // triggering java.lang.ClassNotFoundException
+                BlackHole.consume(Caffeine.class);
+            } catch (final Throwable ignored) {
+                break caffeineCache;
+            }
+            factory = new CaffeineCacheFactory();
+        }
+
+        if (factory == null) factory = CacheFactory.never();
+
+        FACTORY = factory;
+    }
+
+    /**
+     * Creates a new cache whose keys will be stored {@link java.lang.ref.WeakReference weakly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return weak keys cache
+     */
+    public <K, V> @NotNull Cache<K, V> weakKeysCache() {
+        return FACTORY.weakKeysCache();
+    }
+
+    /**
+     * Creates a new cache whose values will be stored {@link java.lang.ref.WeakReference weakly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return weak values cache
+     */
+    public <K, V> @NotNull Cache<K, V> weakValuesCache() {
+        return FACTORY.weakValuesCache();
+    }
+
+    /**
+     * Creates a new cache whose values will be stored {@link java.lang.ref.WeakReference softly}.
+     *
+     * @param <K> type of cache keys
+     * @param <V> type of cached values
+     * @return soft values cache
+     */
+    public <K, V> @NotNull Cache<K, V> softValuesCache() {
+        return FACTORY.softValuesCache();
+    }
+
+    /**
+     * {@link Cache}-wrapper of <a href="https://github.com/ben-manes/caffeine">Caffeine</a> Cache.
+     */
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class CaffeineCacheFactory implements CacheFactory {
+
+        /**
+         * Wraps the provided {@link com.github.benmanes.caffeine.cache.Cache Caffeine Cache} into {@link Cache}.
+         *
+         * @param caffeineCache Caffeine Cache to be wrapped
+         * @param <K> type of cache keys
+         * @param <V> type of cached values
+         * @return wrapped Caffeine Cache
+         */
+        private static <K, V> @NotNull Cache<K, V> wrap(
+                final @NotNull com.github.benmanes.caffeine.cache.Cache<K, V> caffeineCache
+        ) {
+            return caffeineCache::get;
+        }
+
+        @Override
+        public @NotNull <K, V> Cache<K, V> weakKeysCache() {
+            return wrap(Caffeine.newBuilder().weakKeys().build());
+        }
+
+        @Override
+        public <K, V> @NotNull Cache<K, V> weakValuesCache() {
+            return wrap(Caffeine.newBuilder().weakValues().build());
+        }
+
+        @Override
+        public @NotNull <K, V> Cache<K, V> softValuesCache() {
+            return wrap(Caffeine.newBuilder().softValues().build());
+        }
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/collection/CollectionFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/collection/CollectionFactory.java
@@ -1,7 +1,5 @@
 package ru.progrm_jarvis.javacommons.collection;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import javassist.*;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -13,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 import ru.progrm_jarvis.javacommons.bytecode.CommonBytecodeLibrary;
 import ru.progrm_jarvis.javacommons.bytecode.annotation.UsesBytecodeModification;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.classloading.ClassNamingStrategy;
 import ru.progrm_jarvis.javacommons.classloading.GcClassDefiners;
 import ru.progrm_jarvis.javacommons.lazy.Lazy;
@@ -52,8 +52,7 @@ public class CollectionFactory {
     /**
      * Cache of instances of generated enum sets using naturally sorted array of its elements as the key
      */
-    private final @NonNull Cache<Enum<?>[], Set<Enum<?>>> IMMUTABLE_ENUM_SETS
-            = Caffeine.newBuilder().weakValues().build();
+    private final @NonNull Cache<Enum<?>[], Set<Enum<?>>> IMMUTABLE_ENUM_SETS = Caches.weakValuesCache();
 
     /**
      * {@link CtClass} representation of {@link AbstractImmutableSet} wrapped in {@link Lazy}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/AsmDelegateFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/AsmDelegateFactory.java
@@ -1,7 +1,5 @@
 package ru.progrm_jarvis.javacommons.delegate;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.experimental.UtilityClass;
 import lombok.val;
 import lombok.var;
@@ -13,6 +11,8 @@ import ru.progrm_jarvis.javacommons.annotation.Internal;
 import ru.progrm_jarvis.javacommons.bytecode.CommonBytecodeLibrary;
 import ru.progrm_jarvis.javacommons.bytecode.annotation.UsesBytecodeModification;
 import ru.progrm_jarvis.javacommons.bytecode.asm.AsmUtil;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.classloading.ClassNamingStrategy;
 import ru.progrm_jarvis.javacommons.classloading.GcClassDefiners;
 
@@ -261,9 +261,7 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
          * Instance of {@link AsmDelegateFactory ASM-based delegate factory}
          */
         private final @NotNull DelegateFactory INSTANCE = new AsmDelegateFactory(
-                Caffeine.newBuilder()
-                        .weakKeys() // classes are GC-friendly loaded so they may be effectively weakly-referenced
-                        .build()
+                Caches.weakKeysCache() // classes are GC-friendly loaded so they may be effectively weakly-referenced
         );
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/CachingGeneratingDelegateFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/CachingGeneratingDelegateFactory.java
@@ -1,10 +1,10 @@
 package ru.progrm_jarvis.javacommons.delegate;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
 
 import java.util.function.Supplier;
 

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/invoke/InvokeUtil.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/invoke/InvokeUtil.java
@@ -1,12 +1,12 @@
 package ru.progrm_jarvis.javacommons.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -72,10 +72,8 @@ public class InvokeUtil {
      */
     public final @NotNull MethodType SUPPLIER_OBJECT__METHOD_TYPE = methodType(Supplier.class, Object.class);
 
-    private final @NonNull Cache<@NotNull Class<?>, @NotNull Lookup> LOOKUPS
-            = Caffeine.newBuilder()
-            .softValues() // because there is no need to GC lookups which may be expansive to create
-            .build();
+    // because there is no need to GC lookups which may be expansive to create
+    private final @NonNull Cache<@NotNull Class<?>, @NotNull Lookup> LOOKUPS = Caches.softValuesCache();
 
     /**
      * Lookup factory which delegated its calls to {@link InvokeUtil#lookup(Class)}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/BlackHole.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/BlackHole.java
@@ -1,0 +1,21 @@
+package ru.progrm_jarvis.javacommons.util;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Black hole. Helper class used to {@link #consume(Object)} values without any visible side effects.
+ */
+@UtilityClass
+public class BlackHole {
+
+    /**
+     * Consumes the provided value without any visible side effects.
+     * This may be used for scenarios when an arbitrary expression has to be treated as a statement,
+     * for example{@code String.class}</pre> is an expression but not a statement
+     * but <pre>{@code BlackHole.consume(String.class)}</pre> is.
+     *
+     * @param value consumed value
+     * @param <T> type of consumed value
+     */
+    public <T> void consume(@SuppressWarnings("unused") final T value) {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -163,12 +163,14 @@
             </dependency>
 
             <!-- Libraries -->
+            <!-- Caching -->
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
-                <version>2.9.1</version>
+                <version>3.0.3</version>
+                <scope>provided</scope>
+                <optional>true</optional>
             </dependency>
-
             <!-- Bytecode generation -->
             <dependency>
                 <groupId>org.ow2.asm</groupId>

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeConstructorWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeConstructorWrapper.java
@@ -1,7 +1,5 @@
 package ru.progrm_jarvis.reflector.wrapper.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -9,6 +7,8 @@ import lombok.experimental.FieldDefaults;
 import lombok.val;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.javacommons.util.function.ThrowingFunction;
 import ru.progrm_jarvis.reflector.wrapper.AbstractConstructorWrapper;
@@ -35,7 +35,7 @@ public class InvokeConstructorWrapper<@NotNull T>
      * Weak cache of allocated instance of this constructor wrapper
      */
     protected static final @NotNull Cache<@NotNull Constructor<?>, @NotNull ConstructorWrapper<?>> WRAPPER_CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
 
     /**
      * Function performing the constructor invocation

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeDynamicFieldWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeDynamicFieldWrapper.java
@@ -1,12 +1,12 @@
 package ru.progrm_jarvis.reflector.wrapper.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.reflector.wrapper.AbstractFieldWrapper;
 import ru.progrm_jarvis.reflector.wrapper.DynamicFieldWrapper;
@@ -31,7 +31,7 @@ public class InvokeDynamicFieldWrapper<@NotNull T, V>
      * Weak cache of allocated instance of this dynamic field wrapper
      */
     protected static final @NotNull Cache<@NotNull Field, @NotNull DynamicFieldWrapper<?, ?>> CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
 
     /**
      * Function performing the field get operation

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeDynamicMethodWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeDynamicMethodWrapper.java
@@ -1,13 +1,13 @@
 package ru.progrm_jarvis.reflector.wrapper.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.javacommons.util.function.ThrowingBiFunction;
 import ru.progrm_jarvis.reflector.wrapper.AbstractMethodWrapper;
@@ -37,7 +37,7 @@ public class InvokeDynamicMethodWrapper<@NotNull T, R>
      * Weak cache of allocated instance of this constructor wrapper
      */
     private static final @NotNull Cache<@NotNull Method, @NotNull DynamicMethodWrapper<?, ?>> CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
 
     /**
      * Bi-function performing the method invocation

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeStaticFieldWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeStaticFieldWrapper.java
@@ -1,13 +1,13 @@
 package ru.progrm_jarvis.reflector.wrapper.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.javacommons.object.Pair;
 import ru.progrm_jarvis.reflector.wrapper.AbstractFieldWrapper;
@@ -33,13 +33,13 @@ public class InvokeStaticFieldWrapper<@NotNull T, V>
      * Weak cache of allocated instance of this static field wrappers of static fields
      */
     protected static final @NotNull Cache<@NotNull Field, @NotNull StaticFieldWrapper<?, ?>> STATIC_WRAPPER_CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
     /**
      * Weak cache of allocated instance of this static field wrappers of non-static bound fields
      */
     protected static final @NotNull Cache<
             @NotNull Pair<@NotNull Field, @NotNull ?>, @NotNull StaticFieldWrapper<?, ?>
-            > BOUND_WRAPPER_CACHE = Caffeine.newBuilder().weakValues().build();
+            > BOUND_WRAPPER_CACHE = Caches.weakValuesCache();
     /**
      * Supplier performing the field get operation
      */

--- a/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeStaticMethodWrapper.java
+++ b/reflector/src/main/java/ru/progrm_jarvis/reflector/wrapper/invoke/InvokeStaticMethodWrapper.java
@@ -1,13 +1,13 @@
 package ru.progrm_jarvis.reflector.wrapper.invoke;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.cache.Cache;
+import ru.progrm_jarvis.javacommons.cache.Caches;
 import ru.progrm_jarvis.javacommons.invoke.InvokeUtil;
 import ru.progrm_jarvis.javacommons.object.Pair;
 import ru.progrm_jarvis.javacommons.util.function.ThrowingFunction;
@@ -35,14 +35,14 @@ public class InvokeStaticMethodWrapper<@NotNull T, R>
      * Weak cache of allocated instance of this static method wrappers of static methods
      */
     protected static final @NotNull Cache<@NotNull Method, @NotNull StaticMethodWrapper<?, ?>> STATIC_WRAPPER_CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
     /**
      * Weak cache of allocated instance of this static method wrappers of non-static bound methods
      */
     protected static final @NotNull Cache<
             @NotNull Pair<@NotNull Method, @NotNull ?>, @NotNull StaticMethodWrapper<?, ?>
             > BOUND_WRAPPER_CACHE
-            = Caffeine.newBuilder().weakValues().build();
+            = Caches.weakValuesCache();
     /**
      * Function performing the method invocation
      */


### PR DESCRIPTION
# Description

This adds `Cache` and `CacheFactory` interfaces to abstract away from Caffeine by providing automatic implementation pickup which fallback to no-op cache.

This also contains a `BlackHole` utility for expression->statement source code convertion.