### PR TITLE
Add `padla-bom` module

### DIFF
--- a/java-commons/pom.xml
+++ b/java-commons/pom.xml
@@ -2,10 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <artifactId>padla</artifactId>
         <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-commons</artifactId>

--- a/java-commons/pom.xml
+++ b/java-commons/pom.xml
@@ -48,10 +48,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/padla-bom/pom.xml
+++ b/padla-bom/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>padla-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>PADLA BOM</name>
+    <description>PADLA's Bill Of Materials</description>
+
+    <dependencyManagement>
+        <!-- Note: variables cannot be used here as this would allow version overriding -->
+        <dependencies>
+            <dependency>
+                <groupId>ru.progrm-jarvis</groupId>
+                <artifactId>java-commons</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis</groupId>
+                <artifactId>reflector</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>ru.progrm-jarvis</groupId>
+                <artifactId>ultimate-messenger</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <!-- Testing -->
-        <version.junit>5.7.2</version.junit>
-        <version.junit.platform>1.7.2</version.junit.platform>
+        <!-- Duplicated dependency versions -->
         <version.mockito>3.12.4</version.mockito>
     </properties>
 
@@ -163,6 +161,15 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- BOMs -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.0-RC1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Libraries -->
             <!-- Caching -->
             <dependency>
@@ -208,46 +215,9 @@
 
             <!-- Testing -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>${version.junit.platform}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <!-- Specified in case it is needed (though tests run normally without it) -->
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-runner</artifactId>
-                <version>${version.junit.platform}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-surefire-provider</artifactId>
-                <version>1.3.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>ru.progrm-jarvis</groupId>
     <artifactId>padla</artifactId>
     <version>1.0.0-SNAPSHOT</version>
@@ -11,6 +10,7 @@
         <module>reflector</module>
         <module>ultimate-messenger</module>
         <module>tools</module>
+        <module>padla-bom</module>
     </modules>
     <packaging>pom</packaging>
 
@@ -151,6 +151,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Own dependencies -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>java-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -367,4 +367,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
+                    <configuration>
+                        <parallel>all</parallel>
+                        <useUnlimitedThreads>true</useUnlimitedThreads>
+                    </configuration>
                 </plugin>
 
                 <!-- Maven-central deployment-related plugins -->

--- a/reflector/pom.xml
+++ b/reflector/pom.xml
@@ -2,10 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <artifactId>padla</artifactId>
         <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>reflector</artifactId>

--- a/reflector/pom.xml
+++ b/reflector/pom.xml
@@ -25,6 +25,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <artifactId>padla</artifactId>
         <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>padla-tools</artifactId>
+    <packaging>pom</packaging>
     <modules>
         <module>unsafe-methods-access-generator</module>
     </modules>
-    <packaging>pom</packaging>
 
     <build>
         <defaultGoal>clean package</defaultGoal>
@@ -50,5 +49,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
 </project>

--- a/tools/unsafe-methods-access-generator/pom.xml
+++ b/tools/unsafe-methods-access-generator/pom.xml
@@ -2,10 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <artifactId>padla-tools</artifactId>
         <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla-tools</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>unsafe-methods-access-generator</artifactId>

--- a/ultimate-messenger/pom.xml
+++ b/ultimate-messenger/pom.xml
@@ -44,10 +44,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/ultimate-messenger/pom.xml
+++ b/ultimate-messenger/pom.xml
@@ -2,10 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
-        <artifactId>padla</artifactId>
         <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>ultimate-messenger</artifactId>


### PR DESCRIPTION
# Description

This adds `padla-bom` module to allow easier importing of modules.

This also cleans up POMs and enables `parallel` support of `surefire`.