### PR TITLE
Use singleton instance of `CaffeineCacheFactory`

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/CaffeineCache.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/cache/CaffeineCache.java
@@ -39,7 +39,7 @@ public class CaffeineCache {
      * @throws IllegalStateException if Caffeine is not available
      */
     public static @NotNull CacheFactory createFactory() {
-        if (AVAILABLE) return new CaffeineCacheFactory();
+        if (AVAILABLE) return CaffeineCacheFactory.INSTANCE;
 
         throw new IllegalStateException("Caffeine Cache is not available");
     }


### PR DESCRIPTION
# Description

This replaces constructor call with singleton field access of `CaffeineCacheFactory` in `CaffeineCache#createFactory()`.