### PR TITLE
Add `Runnables`

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/collection/Iterables.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/collection/Iterables.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.*;
 
 /**
- * Utilities related to {@link Iterable} iterables.
+ * Utilities related to {@link Iterable iterables}.
  */
 @UtilityClass
 public class Iterables {

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
@@ -1,7 +1,14 @@
 package ru.progrm_jarvis.javacommons.util.function;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Utilities related to {@link Runnable runnables}.
@@ -16,5 +23,82 @@ public class Runnables {
      */
     public @NotNull Runnable none() {
         return () -> {};
+    }
+
+    /**
+     * Creates a stateful runnable which stores its state mutably.
+     *
+     * @param initialState initial state of the created runnable
+     * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
+     * @param <T> type of stored state
+     * @return created stateful runnable
+     */
+    public <T> @NotNull Runnable stateful(final @NotNull T initialState,
+                                          final @NotNull Consumer<? super T> handler) {
+        return new StatefulImmutableRunnable<>(handler, initialState);
+    }
+
+    /**
+     * Creates a stateful runnable which stores its state immutably.
+     *
+     * @param initialState initial state of the created runnable
+     * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
+     * providing the new state
+     * @param <T> type of stored state
+     * @return created stateful runnable
+     */
+    public <T> @NotNull Runnable stateful(final @NotNull T initialState,
+                                          final @NotNull Function<? super T, ? extends T> handler) {
+        return new StatefulMutableRunnable<>(handler, initialState);
+    }
+
+    /**
+     * Stateful {@link Runnable runnable} which stores its state immutably.
+     *
+     * @param <T> type of stored state
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class StatefulImmutableRunnable<T> implements Runnable {
+
+        /**
+         * Handler invoked on each call to {@link #run()} with the state applied to it
+         */
+        @NotNull Consumer<? super T> handler;
+
+        /**
+         * State of this runnable
+         */
+        T state;
+
+        @Override
+        public void run() {
+            handler.accept(state);
+        }
+    }
+
+    /**
+     * Stateful {@link Runnable runnable} which stores its state mutably.
+     *
+     * @param <T> type of stored state
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class StatefulMutableRunnable<T> implements Runnable {
+
+        /**
+         * Handler invoked on each call to {@link #run()} with the state applied to it providing the new state
+         */
+        @NotNull Function<? super T, ? extends T> handler;
+
+        /**
+         * State of this runnable
+         */
+        @NonFinal T state;
+
+        @Override
+        public void run() {
+            state = handler.apply(state);
+        }
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
@@ -1,0 +1,20 @@
+package ru.progrm_jarvis.javacommons.util.function;
+
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Utilities related to {@link Runnable runnables}.
+ */
+@UtilityClass
+public class Runnables {
+
+    /**
+     * Creates a runnable which does nothing.
+     *
+     * @return runnable which does nothing
+     */
+    public @NotNull Runnable none() {
+        return () -> {};
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
@@ -2,6 +2,7 @@ package ru.progrm_jarvis.javacommons.util.function;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import lombok.experimental.UtilityClass;
@@ -32,9 +33,11 @@ public class Runnables {
      * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
      * @param <T> type of stored state
      * @return created stateful runnable
+     *
+     * @throws NullPointerException if {@code handler} is {@code null}
      */
-    public <T> @NotNull Runnable stateful(final @NotNull T initialState,
-                                          final @NotNull Consumer<? super T> handler) {
+    public <T> @NotNull Runnable stateful(final T initialState,
+                                          final @NonNull Consumer<? super T> handler) {
         return new StatefulImmutableRunnable<>(handler, initialState);
     }
 
@@ -46,9 +49,11 @@ public class Runnables {
      * providing the new state
      * @param <T> type of stored state
      * @return created stateful runnable
+     *
+     * @throws NullPointerException if {@code handler} is {@code null}
      */
-    public <T> @NotNull Runnable stateful(final @NotNull T initialState,
-                                          final @NotNull Function<? super T, ? extends T> handler) {
+    public <T> @NotNull Runnable stateful(final T initialState,
+                                          final @NonNull Function<? super T, ? extends T> handler) {
         return new StatefulMutableRunnable<>(handler, initialState);
     }
 

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/Runnables.java
@@ -8,8 +8,7 @@ import lombok.experimental.NonFinal;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.*;
 
 /**
  * Utilities related to {@link Runnable runnables}.
@@ -38,7 +37,7 @@ public class Runnables {
      */
     public <T> @NotNull Runnable stateful(final T initialState,
                                           final @NonNull Consumer<? super T> handler) {
-        return new StatefulImmutableRunnable<>(handler, initialState);
+        return new StatefulMutableImRunnable<>(handler, initialState);
     }
 
     /**
@@ -58,13 +57,58 @@ public class Runnables {
     }
 
     /**
+     * Creates a stateful runnable which stores its state immutably.
+     *
+     * @param initialState initial state of the created runnable
+     * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
+     * providing the new state
+     * @return created stateful runnable
+     *
+     * @throws NullPointerException if {@code handler} is {@code null}
+     */
+    public @NotNull Runnable stateful(final int initialState,
+                                      final @NonNull IntUnaryOperator handler) {
+        return new StatefulMutableIntRunnable(handler, initialState);
+    }
+
+    /**
+     * Creates a stateful runnable which stores its state immutably.
+     *
+     * @param initialState initial state of the created runnable
+     * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
+     * providing the new state
+     * @return created stateful runnable
+     *
+     * @throws NullPointerException if {@code handler} is {@code null}
+     */
+    public @NotNull Runnable stateful(final long initialState,
+                                      final @NonNull LongUnaryOperator handler) {
+        return new StatefulMutableLongRunnable(handler, initialState);
+    }
+
+    /**
+     * Creates a stateful runnable which stores its state immutably.
+     *
+     * @param initialState initial state of the created runnable
+     * @param handler handler invoked on each call to {@link Runnable#run()} with the state applied to it
+     * providing the new state
+     * @return created stateful runnable
+     *
+     * @throws NullPointerException if {@code handler} is {@code null}
+     */
+    public @NotNull Runnable stateful(final double initialState,
+                                      final @NonNull DoubleUnaryOperator handler) {
+        return new StatefulMutableDoubleRunnable(handler, initialState);
+    }
+
+    /**
      * Stateful {@link Runnable runnable} which stores its state immutably.
      *
      * @param <T> type of stored state
      */
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-    private static final class StatefulImmutableRunnable<T> implements Runnable {
+    private static final class StatefulMutableImRunnable<T> implements Runnable {
 
         /**
          * Handler invoked on each call to {@link #run()} with the state applied to it
@@ -104,6 +148,75 @@ public class Runnables {
         @Override
         public void run() {
             state = handler.apply(state);
+        }
+    }
+
+    /**
+     * Specialization of {@link StatefulMutableRunnable} for {@code int}s which stores its state mutably.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class StatefulMutableIntRunnable implements Runnable {
+
+        /**
+         * Handler invoked on each call to {@link #run()} with the state applied to it providing the new state
+         */
+        @NotNull IntUnaryOperator handler;
+
+        /**
+         * State of this runnable
+         */
+        @NonFinal int state;
+
+        @Override
+        public void run() {
+            state = handler.applyAsInt(state);
+        }
+    }
+
+    /**
+     * Specialization of {@link StatefulMutableRunnable} for {@code long}s which stores its state mutably.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class StatefulMutableLongRunnable implements Runnable {
+
+        /**
+         * Handler invoked on each call to {@link #run()} with the state applied to it providing the new state
+         */
+        @NotNull LongUnaryOperator handler;
+
+        /**
+         * State of this runnable
+         */
+        @NonFinal long state;
+
+        @Override
+        public void run() {
+            state = handler.applyAsLong(state);
+        }
+    }
+
+    /**
+     * Specialization of {@link StatefulMutableRunnable} for {@code double}s which stores its state mutably.
+     */
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+    private static final class StatefulMutableDoubleRunnable implements Runnable {
+
+        /**
+         * Handler invoked on each call to {@link #run()} with the state applied to it providing the new state
+         */
+        @NotNull DoubleUnaryOperator handler;
+
+        /**
+         * State of this runnable
+         */
+        @NonFinal double state;
+
+        @Override
+        public void run() {
+            state = handler.applyAsDouble(state);
         }
     }
 }


### PR DESCRIPTION
# Description

This adds a `Runnables` utility class which provides the means for:

- [x] creating empty `Runnable`s (in order not to pollute the metaspace with various instances of such)
- [x] creating *stateful* `Runnable`s, i.e. wrappers around `Consumer<T>` or `Function<T, T>` holding the state

# Note

`Function<? super T, & extends T>` was used instead of `UnaryOperator` for `Runnables#stateful(..)` in order to allow more types.