### PR TITLE
docs(README): hide logo under a spoiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# PADLA ![logo](./.branding/logo_512x512.png)
+# PADLA
+<details>
+<summary>Logo</summary>
+
+![logo](./.branding/logo_512x512.png)
+</details>
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
# Description

This hides a logo under a spoiler so that it does not get rendered by default.