### PR TITLE
More `Result` factories

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
@@ -78,6 +78,32 @@ public interface Result<T, E> extends Supplier<T> {
     }
 
     /**
+     * Creates a new {@link #success(Object) successful result} if the value is not {@code null}.
+     *
+     * @param value value which should be non-{@code null} to be considered a successful value
+     * @param <T> type of the successful value
+     * @param <E> any formal type of the error value
+     * @return a {@link #success(Object) successful result} if the {@code value} is not {@code null}
+     * or a {@link #nullError() null error} otherwise
+     */
+    static <T, @Any E> @NotNull Result<@NotNull T, @Nullable E> nonNullSuccess(final @Nullable T value) {
+        return value == null ? nullError() : success(value);
+    }
+
+    /**
+     * Creates a new {@link #error(Object) error result} if the value is not {@code null}.
+     *
+     * @param error value which should be non-{@code null} to be considered an error value
+     * @param <T> any formal type of the successful value
+     * @param <E> type of the error value
+     * @return a {@link #error(Object) error result} if the {@code value} is not {@code null}
+     * or a {@link #nullSuccess() null success} otherwise
+     */
+    static <T, @Any E> @NotNull Result<@Nullable T, @NotNull E> nonNullError(final @Nullable E error) {
+        return error == null ? nullSuccess() : error(error);
+    }
+
+    /**
      * Converts the given {@link Optional} into a {@link #nullError() null-error result}.
      *
      * @param optional optional to be converted into the result

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/SneakyThrower.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/SneakyThrower.java
@@ -1,0 +1,29 @@
+package ru.progrm_jarvis.javacommons.util;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import ru.progrm_jarvis.javacommons.annotation.Any;
+
+/**
+ * Utility used for rethrowing checked exceptions as unchecked.
+ */
+@UtilityClass
+public class SneakyThrower {
+
+    /**
+     * Rethrows the provided throwable without the need to handle it.
+     *
+     * @param exception rethrown exception
+     * @param <X> type of the returned exception
+     * @param <R> any formal return type of this expression
+     *
+     * @return <i>never</i>
+     * @throws X <i>always</i>
+     */
+    @SneakyThrows
+    @SuppressWarnings("JavaDoc") // although the method is not declared to throw `X`, it always does
+    public <X extends Throwable, @Any R> R sneakyThrow(final @NonNull X exception) {
+        throw exception;
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/SneakyThrower.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/SneakyThrower.java
@@ -13,16 +13,15 @@ public class SneakyThrower {
 
     /**
      * Rethrows the provided throwable without the need to handle it.
+     * This <i>always throws</i> {@code X} <i>never returning</i> any value.
      *
      * @param exception rethrown exception
      * @param <X> type of the returned exception
      * @param <R> any formal return type of this expression
      *
      * @return <i>never</i>
-     * @throws X <i>always</i>
      */
     @SneakyThrows
-    @SuppressWarnings("JavaDoc") // although the method is not declared to throw `X`, it always does
     public <X extends Throwable, @Any R> R sneakyThrow(final @NonNull X exception) {
         throw exception;
     }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingBiFunction.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingBiFunction.java
@@ -21,13 +21,27 @@ public interface ThrowingBiFunction<T, U, R, X extends Throwable> extends BiFunc
      * @param u the second function argument
      * @return the function result
      * @throws X if an exception happens
-     *
      */
-    R invoke(T t, U u) throws X;
+    R applyChecked(T t, U u) throws X;
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first function argument
+     * @param u the second function argument
+     * @return the function result
+     * @throws X if an exception happens
+     *
+     * @deprecated in favor of {@link #applyChecked(Object, Object)}
+     */
+    @Deprecated
+    default R invoke(final T t, final U u) throws X {
+        return applyChecked(t, u);
+    }
 
     @Override
     @SneakyThrows
     default R apply(final T t, final U u) {
-        return invoke(t, u);
+        return applyChecked(t, u);
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingFunction.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingFunction.java
@@ -21,11 +21,25 @@ public interface ThrowingFunction<T, R, X extends Throwable> extends Function<T,
      * @return the function result
      * @throws X if an exception happens
      */
-    R invoke(T t) throws X;
+    R applyChecked(T t) throws X;
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument
+     * @return the function result
+     * @throws X if an exception happens
+     *
+     * @deprecated in favor of {@link #applyChecked(Object)}
+     */
+    @Deprecated
+    default R invoke(final T t) throws X {
+        return applyChecked(t);
+    }
 
     @Override
     @SneakyThrows
     default R apply(final T t) {
-        return invoke(t);
+        return applyChecked(t);
     }
 }

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
  *
  * @param <X> the type of the exception thrown by the function
  */
+@FunctionalInterface
 public interface ThrowingRunnable<X extends Throwable> extends Runnable{
 
     /**
@@ -38,12 +39,11 @@ public interface ThrowingRunnable<X extends Throwable> extends Runnable{
     }
 
     /**
-     * Creates an empty (no-op) throwing runnable which always thrown an exception produced by using the factory.
+     * Creates a throwing runnable which always throws an exception produced by using the factory.
      *
      * @param exceptionFactory factory used for creation of the exception
-     * @param <X> any formal type of the (never thrown) exception
+     * @param <X> the type of the exception thrown by the function
      * @return throwing runnable which always throws {@code X} by creating it via the provided factory
-     *
      * @throws NullPointerException if {@code exceptionFactory} is {@code null}
      *
      * @apiNote if the {@code exceptionFactory} produces {@code null}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
@@ -1,0 +1,59 @@
+package ru.progrm_jarvis.javacommons.util.function;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.annotation.Any;
+
+import java.util.function.Supplier;
+
+/**
+ * An extension of {@link Runnable} allowing throwing calls in its body.
+ *
+ * @param <X> the type of the exception thrown by the function
+ */
+public interface ThrowingRunnable<X extends Throwable> extends Runnable{
+
+    /**
+     * Runs an action.
+     *
+     * @throws X if an exception happens
+     */
+    void runChecked() throws X;
+
+    @Override
+    @SneakyThrows
+    default void run() {
+        runChecked();
+    }
+
+    /**
+     * Creates an empty (no-op) throwing runnable.
+     *
+     * @param <X> any formal type of the (never thrown) exception
+     * @return empty throwing runnable
+     */
+    static <@Any X extends Throwable> @NotNull ThrowingRunnable<X> empty() {
+        return () -> {};
+    }
+
+    /**
+     * Creates an empty (no-op) throwing runnable which always thrown an exception produced by using the factory.
+     *
+     * @param exceptionFactory factory used for creation of the exception
+     * @param <X> any formal type of the (never thrown) exception
+     * @return throwing runnable which always throws {@code X} by creating it via the provided factory
+     *
+     * @throws NullPointerException if {@code exceptionFactory} is {@code null}
+     *
+     * @apiNote if the {@code exceptionFactory} produces {@code null}
+     * then {@link NullPointerException} will be thrown when attempting to throw the expected exception
+     */
+    static <@Any X extends Throwable> @NotNull ThrowingRunnable<X> throwing(
+            final @NonNull Supplier<? extends @NotNull X> exceptionFactory
+    ) {
+        return () -> {
+            throw exceptionFactory.get();
+        };
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingSupplier.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingSupplier.java
@@ -1,0 +1,64 @@
+package ru.progrm_jarvis.javacommons.util.function;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.annotation.Any;
+
+import java.util.function.Supplier;
+
+/**
+ * An extension of {@link Supplier} allowing throwing calls in its body.
+ *
+ * @param <T> the type of results supplied by this supplier
+ * @param <X> the type of the exception thrown by the function
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T, X extends Throwable> extends Supplier<T> {
+
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     * @throws X if an exception happens
+     */
+    T getChecked() throws X;
+
+    @Override
+    @SneakyThrows
+    default T get() {
+        return getChecked();
+    }
+
+    /**
+     * Creates throwing supplier which always returns the provided value.
+     *
+     * @param value the value always returned by this factory
+     * @param <T> the type of the supplied result
+     * @param <X> any formal type of the (never thrown) exception
+     * @return created throwing supplier
+     */
+    static <T, @Any X extends Throwable> @NotNull ThrowingSupplier<T, X> returning(final T value) {
+        return () -> value;
+    }
+
+    /**
+     * Creates a throwing supplier which always throws an exception produced by using the factory.
+     *
+     * @param exceptionFactory factory used for creation of the exception
+     * @param <T> any formal type of the (never returned) value
+     * @param <X> the type of the exception thrown by the function
+     * @return throwing runnable which always throws {@code X} by creating it via the provided factory
+     * @throws NullPointerException if {@code exceptionFactory} is {@code null}
+     *
+     * @apiNote if the {@code exceptionFactory} produces {@code null}
+     * then {@link NullPointerException} will be thrown when attempting to throw the expected exception
+     */
+    static <@Any T, X extends Throwable> @NotNull ThrowingSupplier<T, X> throwing(
+            final @NonNull Supplier<? extends @NotNull X> exceptionFactory
+    ) {
+        return () -> {
+            throw exceptionFactory.get();
+        };
+    }
+}


### PR DESCRIPTION
# Description

This adds more result factories for integration with legacy APIs:
- `Result#try*`
- `Result#nonNull*`

This also adds `ThrowingRunnable` and `ThrowingSupplier` and renames SAMs in `ThrowingFunction` and `ThrowingBiFuncrion`. 