### PR TITLE
Resolve minor javadoc issues in `ultimate-messenger`

### DIFF
--- a/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/AsmTextModelFactory.java
+++ b/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/AsmTextModelFactory.java
@@ -5,10 +5,7 @@ import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 import lombok.extern.java.Log;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.*;
 import org.objectweb.asm.*;
 import ru.progrm_jarvis.javacommons.annotation.Internal;
 import ru.progrm_jarvis.javacommons.bytecode.CommonBytecodeLibrary;
@@ -1269,7 +1266,7 @@ public final class AsmTextModelFactory<T, C extends AsmTextModelFactory.Configur
      *
      * @param <T> type of object according to which the created text models are formatted
      */
-    private interface StaticAsmNode<T> extends AbstractGeneratingTextModelFactoryBuilder.StaticNode<T>, AsmNode<T> {
+    private interface StaticAsmNode<T> extends AbstractGeneratingTextModelFactoryBuilder.StaticNode, AsmNode<T> {
 
         /**
          * Checks if this node's text cannot be passed as a raw part
@@ -1346,7 +1343,7 @@ public final class AsmTextModelFactory<T, C extends AsmTextModelFactory.Configur
         }
 
         @Override
-        public int getTextLength() {
+        public @Range(from = 0, to = Integer.MAX_VALUE) int getTextLength() {
             return text.length();
         }
 

--- a/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/JavassistTextModelFactory.java
+++ b/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/format/model/JavassistTextModelFactory.java
@@ -69,7 +69,7 @@ public final class JavassistTextModelFactory<T> implements TextModelFactory<T> {
     @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
     protected static final class JavassistTextModelBuilder<T>
             extends AbstractGeneratingTextModelFactoryBuilder<
-            T, Node<T, StaticNode<T>, DynamicNode<T>>, StaticNode<T>, DynamicNode<T>
+            T, Node<T, StaticNode, DynamicNode<T>>, StaticNode, DynamicNode<T>
             > {
 
         /**
@@ -78,12 +78,12 @@ public final class JavassistTextModelFactory<T> implements TextModelFactory<T> {
         private static final @NotNull MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
         @Override
-        protected @NotNull Node<T, StaticNode<T>, DynamicNode<T>> newStaticNode(final @NotNull String text) {
+        protected @NotNull Node<T, StaticNode, DynamicNode<T>> newStaticNode(final @NotNull String text) {
             return new SimpleStaticNode<>(text);
         }
 
         @Override
-        protected @NotNull Node<T, StaticNode<T>, DynamicNode<T>> newDynamicNode(final @NotNull TextModel<T> content) {
+        protected @NotNull Node<T, StaticNode, DynamicNode<T>> newDynamicNode(final @NotNull TextModel<T> content) {
             return new SimpleDynamicNode<>(content);
         }
 

--- a/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/message/Message.java
+++ b/ultimate-messenger/src/main/java/ru/progrm_jarvis/ultimatemessenger/message/Message.java
@@ -34,7 +34,7 @@ public interface Message<C, R> {
      * @param receivers receivers of the message
      */
     @SuppressWarnings("unchecked") // generic vararg
-    default void send(@NotNull C context, @NotNull R... receivers) {
+    default void send(final @NotNull C context, final @NotNull R... receivers) {
         for (val receiver : receivers) send(context, receiver);
     }
 
@@ -44,11 +44,17 @@ public interface Message<C, R> {
      * @param context context of the message
      * @param receivers receivers of the message
      */
-    default void send(@NotNull C context, @NotNull Iterator<@NotNull R> receivers) {
+    default void send(final @NotNull C context, final @NotNull Iterator<@NotNull R> receivers) {
         while (receivers.hasNext()) send(context, receivers.next());
     }
 
-    default void send(@NotNull C context, @NotNull Spliterator<@NotNull R> receivers) {
+    /**
+     * Sends a message in the given context to each of the receivers.
+     *
+     * @param context context of the message
+     * @param receivers receivers of the message
+     */
+    default void send(final @NotNull C context, final @NotNull Spliterator<@NotNull R> receivers) {
         receivers.forEachRemaining(receiver -> send(context, receiver));
     }
 
@@ -58,7 +64,7 @@ public interface Message<C, R> {
      * @param context context of the message
      * @param receivers receivers of the message
      */
-    default void send(@NotNull C context, @NotNull Iterable<@NotNull R> receivers) {
+    default void send(final @NotNull C context, final @NotNull Iterable<@NotNull R> receivers) {
         for (val receiver : receivers) send(context, receiver);
     }
 
@@ -68,7 +74,7 @@ public interface Message<C, R> {
      * @param context context of the message
      * @param receivers receivers of the message
      */
-    default void send(@NotNull C context, @NotNull Collection<@NotNull R> receivers) {
+    default void send(final @NotNull C context, final @NotNull Collection<@NotNull R> receivers) {
         for (val receiver : receivers) send(context, receiver);
     }
 
@@ -78,7 +84,7 @@ public interface Message<C, R> {
      * @param context context of the message
      * @param receivers receivers of the message
      */
-    default void send(@NotNull C context, @NotNull List<@NotNull R> receivers) {
+    default void send(final @NotNull C context, final @NotNull List<@NotNull R> receivers) {
         for (val receiver : receivers) send(context, receiver);
     }
 }


### PR DESCRIPTION
# Description

This adds missing Javadoc's to `ultimate-messenger`'s compoenents.

This also performs a small refactoring of `AbstractGeneratingTextModelFactoryBuilder.StaticNode` removing redundant generic.
