### PR TITLE
Fix `nexus-staging-maven-plugin` for latest Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,15 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.8</version>
+                    <extensions>true</extensions>
+                    <dependencies>
+                        <!-- Manual fix of Plugin crash on latest Java versions -->
+                        <dependency>
+                            <groupId>com.thoughtworks.xstream</groupId>
+                            <artifactId>xstream</artifactId>
+                            <version>1.4.18</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# Description

This updates plugin's dependency on `xstream` so that it works on Java 17.﻿
