### PR TITLE
Add more methods to `Result` to make it more easy to use with `Throwable`s.

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
@@ -164,13 +164,13 @@ public interface Result<T, E> extends Supplier<T> {
      * @return {@link #success(Object) successful result} if the supplier provides the value unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable} otherwise
      */
-    static <T> Result<T, @NotNull Exception> tryGet(
+    static <T> Result<T, @NotNull Throwable> tryGet(
             final @NonNull ThrowingSupplier<? extends T, ? extends Throwable> supplier
     ) {
         final T value;
         try {
-            value = supplier.get();
-        } catch (final Exception x) {
+            value = supplier.getChecked();
+        } catch (final Throwable x) {
             return error(x);
         }
 

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/Result.java
@@ -168,7 +168,7 @@ public interface Result<T, E> extends Supplier<T> {
      * @param <X> type of the thrown throwable
      * @return {@link #nullSuccess() successful void-result} if the runnable runs unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable}
-     * if {@link Class#isAssignableFrom(Class) it is of} the expected type
+     * if {@link Class#isInstance(Object) it is of} the expected type
      * @apiNote if an unexpected exception is thrown then it will be rethrown
      */
     @SuppressWarnings("unchecked")
@@ -180,7 +180,7 @@ public interface Result<T, E> extends Supplier<T> {
         try {
             runnable.runChecked();
         } catch (final Throwable x) {
-            if (throwableType.isAssignableFrom(x.getClass())) return error((X) x);
+            if (throwableType.isInstance(x)) return error((X) x);
 
             return SneakyThrower.sneakyThrow(x);
         }
@@ -196,7 +196,7 @@ public interface Result<T, E> extends Supplier<T> {
      * @param <X> type of the thrown throwable
      * @return {@link #nullSuccess() successful void-result} if the runnable runs unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable}
-     * if {@link Class#isAssignableFrom(Class) it is of} the expected type
+     * if {@link Class#isInstance(Object) it is of} the expected type
      * @apiNote if an unexpected exception is thrown then it will be rethrown
      */
     @SafeVarargs
@@ -214,8 +214,6 @@ public interface Result<T, E> extends Supplier<T> {
      * @param supplier provider of the result whose failure indicates the {@link #error(Object) error result}
      * @return {@link #success(Object) successful result} if the supplier provides the value unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable}
-     * if {@link Class#isAssignableFrom(Class) it is of} the expected type
-     * @apiNote if an unexpected exception is thrown then it will be rethrown
      */
     static <T> Result<T, @NotNull Throwable> tryGet(
             final @NonNull ThrowingSupplier<? extends T, Throwable> supplier
@@ -238,7 +236,8 @@ public interface Result<T, E> extends Supplier<T> {
      * @param <T> type of the {@link #success(Object) successful result} provided by the given supplier
      * @return {@link #success(Object) successful result} if the supplier provides the value unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable}
-     * if {@link Class#isAssignableFrom(Class) it is of} the expected type
+     * if {@link Class#isInstance(Object) it is of} the expected type
+     * if {@link Class#isInstance(Object) it is of} the expected type
      * @apiNote if an unexpected exception is thrown then it will be rethrown
      */
     @SuppressWarnings("unchecked")
@@ -251,7 +250,7 @@ public interface Result<T, E> extends Supplier<T> {
         try {
             value = supplier.getChecked();
         } catch (final Throwable x) {
-            if (throwableType.isAssignableFrom(x.getClass())) return error((X) x);
+            if (throwableType.isInstance(x)) return error((X) x);
 
             return SneakyThrower.sneakyThrow(x);
         }
@@ -268,6 +267,8 @@ public interface Result<T, E> extends Supplier<T> {
      * @param <T> type of the {@link #success(Object) successful result} provided by the given supplier
      * @return {@link #success(Object) successful result} if the supplier provides the value unexceptionally
      * or an {@link #error(Object) error result} containing the thrown {@link Throwable throwable} otherwise
+     * if {@link Class#isInstance(Object) it is of} the expected type
+     * @apiNote if an unexpected exception is thrown then it will be rethrown
      */
     @SafeVarargs
     static <T, X extends Throwable> Result<T, @NotNull X> tryGetChecked(

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/util/function/ThrowingRunnable.java
@@ -13,7 +13,7 @@ import java.util.function.Supplier;
  * @param <X> the type of the exception thrown by the function
  */
 @FunctionalInterface
-public interface ThrowingRunnable<X extends Throwable> extends Runnable{
+public interface ThrowingRunnable<X extends Throwable> extends Runnable {
 
     /**
      * Runs an action.

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/ResultTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/ResultTest.java
@@ -13,72 +13,72 @@ import static org.junit.jupiter.api.Assertions.*;
 class ResultTest {
 
     @Test
-    void test_tryRunChecked_withInferredType_success() {
+    void test_tryRun_withInferredType_success() {
         assertTrue(
-                Result.tryRunChecked(TestMethods::voidMethodNotThrowingDeclaredIOException).isSuccess()
+                Result.tryRun(TestMethods::voidMethodNotThrowingDeclaredIOException).isSuccess()
         );
     }
 
     @Test
-    void test_tryRunChecked_withInferredType_error() {
+    void test_tryRun_withInferredType_error() {
         val thrown = new IOException("Expected exception");
         assertSame(thrown,
-                Result.tryRunChecked(() -> TestMethods.voidMethodThrowingDeclaredIOException(thrown)).unwrapError()
+                Result.tryRun(() -> TestMethods.voidMethodThrowingDeclaredIOException(thrown)).unwrapError()
         );
     }
 
     @Test
-    void test_tryRunChecked_withInferredType_rethrow() {
+    void test_tryRun_withInferredType_rethrow() {
         val thrown = new RuntimeException("You didn't expect it, did you?");
         assertSame(thrown,
-                assertThrows(RuntimeException.class, () -> Result.tryRunChecked(
+                assertThrows(RuntimeException.class, () -> Result.tryRun(
                         () -> TestMethods.voidMethodNotThrowingDeclaredIOExceptionButRuntimeException(thrown)
                 ))
         );
     }
 
     @Test
-    void test_tryRunChecked_withInferredType_typeInference() {
+    void test_tryRun_withInferredType_typeInference() {
         assertTrue(
-                Result.tryRunChecked(() -> TestMethods.voidMethodThrowingCustomException(new CustomException()))
+                Result.tryRun(() -> TestMethods.voidMethodThrowingCustomException(new CustomException()))
                         .peek(aVoid -> fail("Result should be an error result"))
-                        .peekError(customError -> customError.thisIsACustomError())
+                        .peekError(CustomException::thisIsACustomError)
                         .isError()
         );
     }
 
     @Test
-    void test_tryGetChecked_withInferredType_success() {
+    void test_tryGet_withInferredType_success() {
         val returned = "Hello world";
         assertSame(returned,
-                Result.tryGetChecked(() -> TestMethods.stringMethodNotThrowingDeclaredIOException(returned)).unwrap()
+                Result.tryGet(() -> TestMethods.stringMethodNotThrowingDeclaredIOException(returned)).unwrap()
         );
     }
 
     @Test
-    void test_tryGetChecked_withInferredType_error() {
+    void test_tryGet_withInferredType_error() {
         val thrown = new IOException("Expected exception");
         assertSame(thrown,
-                Result.tryGetChecked(() -> TestMethods.stringMethodThrowingDeclaredIOException(thrown)).unwrapError()
+                Result.tryGet(() -> TestMethods.stringMethodThrowingDeclaredIOException(thrown)).unwrapError()
         );
     }
 
     @Test
-    void test_tryGetChecked_withInferredType_rethrow() {
+    void test_tryGet_withInferredType_rethrow() {
         val thrown = new RuntimeException("You didn't expect it, did you?");
         assertSame(thrown,
-                assertThrows(RuntimeException.class, () -> Result.tryGetChecked(
+                assertThrows(RuntimeException.class, () -> Result.tryGet(
                         () -> TestMethods.stringMethodNotThrowingDeclaredIOExceptionButRuntimeException(thrown)
                 ))
         );
     }
 
     @Test
-    void test_tryGetChecked_withInferredType_typeInference() {
+    void test_tryGet_withInferredType_typeInference() {
         assertTrue(
-                Result.tryGetChecked(() -> TestMethods.stringMethodThrowingCustomException(new CustomException()))
+                Result.tryGet(() -> TestMethods.stringMethodThrowingCustomException(new CustomException()))
                         .peek(string -> fail("Result should be an error result"))
-                        .peekError(customError -> customError.thisIsACustomError())
+                        .peekError(CustomException::thisIsACustomError)
                         .isError()
         );
     }

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/ResultTest.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/object/ResultTest.java
@@ -1,0 +1,142 @@
+package ru.progrm_jarvis.javacommons.object;
+
+import lombok.NonNull;
+import lombok.experimental.StandardException;
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResultTest {
+
+    @Test
+    void test_tryRunChecked_withInferredType_success() {
+        assertTrue(
+                Result.tryRunChecked(TestMethods::voidMethodNotThrowingDeclaredIOException).isSuccess()
+        );
+    }
+
+    @Test
+    void test_tryRunChecked_withInferredType_error() {
+        val thrown = new IOException("Expected exception");
+        assertSame(thrown,
+                Result.tryRunChecked(() -> TestMethods.voidMethodThrowingDeclaredIOException(thrown)).unwrapError()
+        );
+    }
+
+    @Test
+    void test_tryRunChecked_withInferredType_rethrow() {
+        val thrown = new RuntimeException("You didn't expect it, did you?");
+        assertSame(thrown,
+                assertThrows(RuntimeException.class, () -> Result.tryRunChecked(
+                        () -> TestMethods.voidMethodNotThrowingDeclaredIOExceptionButRuntimeException(thrown)
+                ))
+        );
+    }
+
+    @Test
+    void test_tryRunChecked_withInferredType_typeInference() {
+        assertTrue(
+                Result.tryRunChecked(() -> TestMethods.voidMethodThrowingCustomException(new CustomException()))
+                        .peek(aVoid -> fail("Result should be an error result"))
+                        .peekError(customError -> customError.thisIsACustomError())
+                        .isError()
+        );
+    }
+
+    @Test
+    void test_tryGetChecked_withInferredType_success() {
+        val returned = "Hello world";
+        assertSame(returned,
+                Result.tryGetChecked(() -> TestMethods.stringMethodNotThrowingDeclaredIOException(returned)).unwrap()
+        );
+    }
+
+    @Test
+    void test_tryGetChecked_withInferredType_error() {
+        val thrown = new IOException("Expected exception");
+        assertSame(thrown,
+                Result.tryGetChecked(() -> TestMethods.stringMethodThrowingDeclaredIOException(thrown)).unwrapError()
+        );
+    }
+
+    @Test
+    void test_tryGetChecked_withInferredType_rethrow() {
+        val thrown = new RuntimeException("You didn't expect it, did you?");
+        assertSame(thrown,
+                assertThrows(RuntimeException.class, () -> Result.tryGetChecked(
+                        () -> TestMethods.stringMethodNotThrowingDeclaredIOExceptionButRuntimeException(thrown)
+                ))
+        );
+    }
+
+    @Test
+    void test_tryGetChecked_withInferredType_typeInference() {
+        assertTrue(
+                Result.tryGetChecked(() -> TestMethods.stringMethodThrowingCustomException(new CustomException()))
+                        .peek(string -> fail("Result should be an error result"))
+                        .peekError(customError -> customError.thisIsACustomError())
+                        .isError()
+        );
+    }
+
+    @UtilityClass
+    private class TestMethods {
+
+        @SuppressWarnings("RedundantThrows")
+        private void voidMethodNotThrowingDeclaredIOException() throws IOException {}
+
+        private void voidMethodThrowingDeclaredIOException(
+                final @NonNull IOException thrown
+        ) throws IOException {
+            throw thrown;
+        }
+
+        @SuppressWarnings("RedundantThrows")
+        private void voidMethodNotThrowingDeclaredIOExceptionButRuntimeException(
+                final @NonNull RuntimeException thrown
+        ) throws IOException {
+            throw thrown;
+        }
+
+        @SuppressWarnings("RedundantThrows")
+        private String stringMethodNotThrowingDeclaredIOException(final String returned) throws IOException {
+            return returned;
+        }
+
+        private String stringMethodThrowingDeclaredIOException(
+                final @NonNull IOException thrown
+        ) throws IOException {
+            throw thrown;
+        }
+
+        @SuppressWarnings("RedundantThrows")
+        private String stringMethodNotThrowingDeclaredIOExceptionButRuntimeException(
+                final @NonNull RuntimeException thrown
+        ) throws IOException {
+            throw thrown;
+        }
+
+        @SuppressWarnings("RedundantThrows")
+        private void voidMethodThrowingCustomException(
+                final @NonNull CustomException customException
+        ) throws CustomException {
+            throw customException;
+        }
+
+        @SuppressWarnings("RedundantThrows")
+        private String stringMethodThrowingCustomException(
+                final @NonNull CustomException customException
+        ) throws CustomException {
+            throw customException;
+        }
+    }
+
+    @StandardException
+    private final class CustomException extends Exception {
+        public void thisIsACustomError() {}
+    }
+}


### PR DESCRIPTION
# Description

This adds type-inference support to `Result#try*(..)` family of methods using `@TypeHints`.

This also adds conditional mapping methods to `Extensions`.

# Bugs

This fixes an  accidental bug where non-type-inferred `Result#tryGet` used `Exception` instead of `Throwable`.

# Notes

Conditional mappers cannot be implemented as virtual methods because they require upcasting.