### PR TITLE
docs(java-commons): add missing javadocs to `AbstractManagedPendingService`'s `protected` methods

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/service/AbstractManagedPendingService.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/service/AbstractManagedPendingService.java
@@ -83,8 +83,19 @@ public abstract class AbstractManagedPendingService<O, S, R> implements ManagedP
         }
     }
 
+    /**
+     * Creates a service for the provided owner.
+     *
+     * @param owner owner of the created service
+     * @return creates service
+     */
     protected abstract S newService(@NonNull O owner);
 
+    /**
+     * Marks the provided owner as ready.
+     *
+     * @param owner owner which should now be considered ready
+     */
     @SuppressWarnings("resource") // close() is already the cause of this method being called
     protected void markAsReady(final @NonNull O owner) {
         final Lock lock;
@@ -226,6 +237,12 @@ public abstract class AbstractManagedPendingService<O, S, R> implements ManagedP
             closed = new AtomicBoolean();
         }
 
+        /**
+         * Triggers the failure due to this service being closed.
+         *
+         * @throws IllegalStateException <i>always</i>
+         */
+        @SuppressWarnings("MethodMayBeStatic") // overriding classes may implement instance-specific behaviour
         protected void failOnClosed() {
             throw new IllegalStateException("This managed service has already been closed");
         }

--- a/ultimate-messenger/src/test/java/ru/progrm_jarvis/ultimatemessenger/format/placeholder/SimplePlaceholdersTest.java
+++ b/ultimate-messenger/src/test/java/ru/progrm_jarvis/ultimatemessenger/format/placeholder/SimplePlaceholdersTest.java
@@ -47,10 +47,10 @@ class SimplePlaceholdersTest {
                         arguments(target, "{:} hello", "{:} hello"),
                         arguments(target, "hello {:}", "hello {:}"),
                         arguments(target, "{:} hello {:}", "{:} hello {:}"),
-                        arguments(target, "{rand} hello {:}", "??? hello {:}"),
-                        arguments(target, "{rand} hello {rand}", "??? hello ???"),
-                        arguments(target, "{rand} hello {:}", "??? hello {:}"),
-                        arguments(target, "{unknown:} hello {:}", "??? hello {:}")
+                        arguments(target, "{rand} hello {:}", "<?> hello {:}"),
+                        arguments(target, "{rand} hello {rand}", "<?> hello <?>"),
+                        arguments(target, "{rand} hello {:}", "<?> hello {:}"),
+                        arguments(target, "{unknown:} hello {:}", "<?> hello {:}")
                 ));
     }
 
@@ -102,11 +102,11 @@ class SimplePlaceholdersTest {
                         arguments(target, "hello \\{:}\\", "hello {:}\\"),
                         arguments(target, "\\{\\:\\}\\ hello \\{\\:\\}", "{:} hello {:}"),
                         arguments(target, "\\{\\:\\}\\ hello \\{\\:\\}\\", "{:} hello {:}\\"),
-                        arguments(target, "{\\ran\\d} hello {:}", "??? hello {:}"),
-                        arguments(target, "{rand\\} \\hello {rand}", "???"),
-                        arguments(target, "{rand\\} hello \\{:}", "???"),
-                        arguments(target, "{unknown:\\} hi\\\\ {:}", "???"),
-                        arguments(target, "{unknown:\\\\} <magic", "??? <magic")
+                        arguments(target, "{\\ran\\d} hello {:}", "<?> hello {:}"),
+                        arguments(target, "{rand\\} \\hello {rand}", "<?>"),
+                        arguments(target, "{rand\\} hello \\{:}", "<?>"),
+                        arguments(target, "{unknown:\\} hi\\\\ {:}", "<?>"),
+                        arguments(target, "{unknown:\\\\} <magic", "<?> <magic")
                 ));
     }
 
@@ -203,7 +203,7 @@ class SimplePlaceholdersTest {
     @BeforeEach
     void setUp() {
         placeholders = SimplePlaceholders.<Target>builder().build();
-        placeholders.add("*", ((value, target) -> "#"));
+        placeholders.add("*", (value, target) -> "#");
         placeholders.add("test", (value, target) -> {
             switch (value) {
                 case "name": return target.name;


### PR DESCRIPTION
# Description

This adds missing documentation to `protected` methods of `AbstractManagedPendingService`.