### PR TITLE
build: remove redundant `dependencies` from `nexus-staging-maven-plugin` configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,19 +217,6 @@
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
-                    <dependencies>
-                        <!-- Manual fix of Plugin crash on latest Java versions -->
-                        <dependency>
-                            <groupId>com.thoughtworks.xstream</groupId>
-                            <artifactId>xstream</artifactId>
-                            <version>1.4.17</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.ogce</groupId>
-                            <artifactId>xpp3</artifactId>
-                            <version>1.1.6</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# Description

This removes no loner needed `dependencies` configuration of `nexus-staging-maven-plugin` which was updated in #329.