### PR TITLE
build(dep): use ASM BOM

### DIFF
--- a/java-commons/pom.xml
+++ b/java-commons/pom.xml
@@ -31,6 +31,8 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,13 @@
 
             <!-- BOMs -->
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-bom</artifactId>
+                <version>9.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>5.8.2</version>
@@ -268,13 +275,6 @@
                 <optional>true</optional>
             </dependency>
             <!-- Bytecode generation -->
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>9.3</version>
-                <scope>provided</scope>
-                <optional>true</optional>
-            </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>

--- a/ultimate-messenger/pom.xml
+++ b/ultimate-messenger/pom.xml
@@ -23,6 +23,8 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
This replaces explicit ASM dependency configuration with BOM-provided.