### PR TITLE
feat: implement `DelegateFactory` with `Proxy` API

### DIFF
--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/AsmDelegateFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/AsmDelegateFactory.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
-import ru.progrm_jarvis.javacommons.annotation.Internal;
 import ru.progrm_jarvis.javacommons.bytecode.CommonBytecodeLibrary;
 import ru.progrm_jarvis.javacommons.bytecode.annotation.UsesBytecodeModification;
 import ru.progrm_jarvis.javacommons.bytecode.asm.AsmUtil;
@@ -52,33 +51,37 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
     /**
      * Name of the generated field in which the lazy will be stored
      */
-    private static final @NotNull String GENERATED_INNER_LAZY_FIELD_NAME = "$" ,
+    private static final @NotNull String GENERATED_INNER_LAZY_FIELD_NAME = "$";
+
     /**
      * Name of {@link Supplier#get()} method
      */
-    GET_METHOD_NAME = "get" ,
+    private static final @NotNull String GET_METHOD_NAME = "get";
+
     /**
      * Internal name of {@link Supplier}
      */
-    SUPPLIER_INTERNAL_NAME = SUPPLIER_TYPE.getInternalName(),
+    private static final @NotNull String SUPPLIER_INTERNAL_NAME = SUPPLIER_TYPE.getInternalName();
+
     /**
      * Descriptor of {@link Supplier}
      */
-    SUPPLIER_DESCRIPTOR = SUPPLIER_TYPE.getDescriptor(),
+    private static final @NotNull String SUPPLIER_DESCRIPTOR = SUPPLIER_TYPE.getDescriptor();
+
     /**
      * Descriptor of {@code void(}{@link Supplier}{@code )} method
      */
-    VOID_SUPPLIER_METHOD_DESCRIPTOR = getMethodDescriptor(VOID_TYPE, SUPPLIER_TYPE);
+    private static final @NotNull String VOID_SUPPLIER_METHOD_DESCRIPTOR
+            = getMethodDescriptor(VOID_TYPE, SUPPLIER_TYPE);
 
     private AsmDelegateFactory(final @NotNull Cache<@NotNull Class<?>, @NotNull DelegateWrapperFactory<?>> factories) {
         super(factories);
     }
 
     /**
-     * Creates an {@link DelegateFactory ASM-based supplier wrapper}.
+     * Creates an ASM-based {@link DelegateFactory delegate factory}.
      *
-     * @return ASM-based supplier wrapper
-     *
+     * @return ASM-based delegate factory
      * @apiNote singleton may be used here
      */
     public static DelegateFactory create() {
@@ -94,7 +97,7 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
             try {
                 constructor = generatedClass.getDeclaredConstructor(Supplier.class);
             } catch (final NoSuchMethodException e) {
-                throw new Error("Could not get an empty constructor of the generated class" , e);
+                throw new Error("Could not get an empty constructor of the generated class", e);
             }
             constructor.setAccessible(true);
         }
@@ -103,7 +106,7 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
             try {
                 return constructor.newInstance(supplier);
             } catch (final IllegalAccessException | InstantiationException | InvocationTargetException e) {
-                throw new Error("Cannot invoke constructor of the generated class" , e);
+                throw new Error("Cannot invoke constructor of the generated class", e);
             }
         };
     }
@@ -113,6 +116,7 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
      *
      * @param targetClass class for which to create a delegate-wrapper
      * @param <T> type of implemented delegate-wrapper
+     *
      * @return created delegate-wrapper for the given type
      */
     private static <T> @NotNull Class<? extends T> generateWrapperClass(final @NotNull Class<T> targetClass) {
@@ -143,7 +147,7 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
                 clazz.visitField(
                         AsmUtil.OPCODES_ACC_PUBLIC_FINAL /* safe to use public here */, GENERATED_INNER_LAZY_FIELD_NAME,
                         SUPPLIER_DESCRIPTOR,
-                        supplierSignature = 'L' + SUPPLIER_INTERNAL_NAME + '<' + targetType.getDescriptor() + ">;" ,
+                        supplierSignature = 'L' + SUPPLIER_INTERNAL_NAME + '<' + targetType.getDescriptor() + ">;",
                         null
                 ).visitEnd();
                 //</editor-fold>
@@ -151,10 +155,12 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
                 //<editor-fold desc="Constructor generation" defaultstate="collapsed">
                 {
                     final MethodVisitor constructor;
-                    (constructor = clazz.visitMethod(
-                            ACC_PUBLIC, AsmUtil.CONSTRUCTOR_METHOD_NAME, VOID_SUPPLIER_METHOD_DESCRIPTOR,
-                            '(' + supplierSignature + ")V" , null /* no exceptions */
-                    )).visitCode();
+                    (
+                            constructor = clazz.visitMethod(
+                                    ACC_PUBLIC, AsmUtil.CONSTRUCTOR_METHOD_NAME, VOID_SUPPLIER_METHOD_DESCRIPTOR,
+                                    '(' + supplierSignature + ")V", null /* no exceptions */
+                            )
+                    ).visitCode();
 
                     // push `this` onto the stack
                     constructor.visitVarInsn(ALOAD, 0);
@@ -197,10 +203,12 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
                             for (var i = 0; i < parametersLength; i++) exceptions[i] = getDescriptor(exceptionTypes[i]);
                         }
 
-                        (method = clazz.visitMethod(
-                                ACC_PUBLIC, methodName = originalMethod.getName(),
-                                methodDescriptor = getMethodDescriptor(originalMethod), null, exceptions
-                        )).visitVarInsn(ALOAD, 0); // push `this` onto the stack
+                        (
+                                method = clazz.visitMethod(
+                                        ACC_PUBLIC, methodName = originalMethod.getName(),
+                                        methodDescriptor = getMethodDescriptor(originalMethod), null, exceptions
+                                )
+                        ).visitVarInsn(ALOAD, 0); // push `this` onto the stack
                     }
                     // get field storing the Supplier
                     method.visitFieldInsn(GETFIELD, internalName, GENERATED_INNER_LAZY_FIELD_NAME, SUPPLIER_DESCRIPTOR);
@@ -252,11 +260,11 @@ public final class AsmDelegateFactory extends CachingGeneratingDelegateFactory {
         }
         //</editor-fold>
 
-        return UncheckedCasts.uncheckedClassCast(GcClassDefiners.getDefault().defineClass(LOOKUP, className, clazz.toByteArray()));
+        return UncheckedCasts.uncheckedClassCast(
+                GcClassDefiners.getDefault().defineClass(LOOKUP, className, clazz.toByteArray()));
     }
 
     @UtilityClass
-    @Internal("Safe singleton implementation using class-loading rules for achieving efficient thread-safe laziness")
     private static class Singleton {
 
         /**

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/DelegateFactories.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/DelegateFactories.java
@@ -1,0 +1,25 @@
+package ru.progrm_jarvis.javacommons.delegate;
+
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.bytecode.CommonBytecodeLibrary;
+
+/**
+ * Utility making use of {@link DelegateFactory delegate factories} easier.
+ */
+@UtilityClass
+public class DelegateFactories {
+
+    /**
+     * Gets the best available {@link DelegateFactory delegate factory}.
+     *
+     * @return the best available {@link DelegateFactory delegate factory}
+     */
+    public @NotNull DelegateFactory createAvailable() {
+        if (CommonBytecodeLibrary.ASM.isAvailable()) try {
+            return AsmDelegateFactory.create();
+        } catch (final Throwable ignored) {}
+
+        return ProxyDelegateFactory.create();
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/ProxyDelegateFactory.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/delegate/ProxyDelegateFactory.java
@@ -1,0 +1,76 @@
+package ru.progrm_jarvis.javacommons.delegate;
+
+import lombok.*;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import ru.progrm_jarvis.javacommons.object.ObjectUtil;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+/**
+ * Implementation of {@link DelegateFactory delegate factory} which uses runtime proxy generation via {@link Proxy}.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ProxyDelegateFactory implements DelegateFactory {
+
+    /**
+     * Creates a proxy-based {@link DelegateFactory delegate factory}.
+     *
+     * @return proxy-based delegate factory
+     * @apiNote singleton may be used here
+     */
+    public static DelegateFactory create() {
+        return Singleton.INSTANCE;
+    }
+
+    @Override
+    public <T> @NotNull T createWrapper(final @NonNull Class<T> targetType, final @NonNull Supplier<T> supplier) {
+        val methodsByName = new HashMap<String, Map<ClassArrayWrapper, Method>>();
+        for (val method : targetType.getDeclaredMethods()) {
+            val previouslyAssociatedMethod = methodsByName
+                    .computeIfAbsent(method.getName(), key -> new HashMap<>())
+                    .put(new ClassArrayWrapper(method.getParameterTypes()), method);
+
+            assert previouslyAssociatedMethod == null
+                    : "there should be no previous method associated with the given name and type";
+        }
+
+        val objectProxy = Proxy.newProxyInstance(
+                targetType.getClassLoader(),
+                new Class[]{targetType},
+                (proxy, method, arguments) -> {
+                    if (arguments == null) arguments = ObjectUtil.EMPTY_ARRAY;
+
+                    return methodsByName
+                            .get(method.getName())
+                            .get(new ClassArrayWrapper(method.getParameterTypes()))
+                            .invoke(supplier.get(), arguments);
+                }
+        );
+
+        assert targetType.isInstance(objectProxy) : "target type should be assignable from the proxy instance";
+
+        @SuppressWarnings("unchecked")
+        val specificProxy = (T) objectProxy;
+        return specificProxy;
+    }
+
+    @Value
+    private class ClassArrayWrapper {
+        Class<?> @NotNull [] array;
+    }
+
+    @UtilityClass
+    private static class Singleton {
+
+        /**
+         * Instance of {@link AsmDelegateFactory ASM-based delegate factory}
+         */
+        private final @NotNull DelegateFactory INSTANCE = new ProxyDelegateFactory();
+    }
+}

--- a/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/ObjectUtil.java
+++ b/java-commons/src/main/java/ru/progrm_jarvis/javacommons/object/ObjectUtil.java
@@ -5,6 +5,7 @@ import lombok.experimental.UtilityClass;
 import lombok.val;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -15,6 +16,11 @@ import java.util.function.Supplier;
  */
 @UtilityClass
 public class ObjectUtil {
+
+    /**
+     * Empty array of objects.
+     */
+    public final @NotNull Object @NotNull @Unmodifiable [] EMPTY_ARRAY = new Object[0];
 
     /**
      * Returns the first nonnull value of specified variants or {@code null} if none found.

--- a/java-commons/src/test/java/ru/progrm_jarvis/javacommons/delegate/DelegateFactoryTests.java
+++ b/java-commons/src/test/java/ru/progrm_jarvis/javacommons/delegate/DelegateFactoryTests.java
@@ -1,25 +1,27 @@
 package ru.progrm_jarvis.javacommons.delegate;
 
 import lombok.val;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-class AsmDelegateFactoryTest {
+class DelegateFactoryTests {
 
-    private DelegateFactory testTarget;
-
-    @BeforeEach
-    void setup() {
-        testTarget = AsmDelegateFactory.create();
+    private static @NotNull Stream<@NotNull Arguments> provideDelegateFactoryImplementations() {
+        return Stream.of(ProxyDelegateFactory.create(), AsmDelegateFactory.create())
+                .map(Arguments::of);
     }
 
-    @Test
-    public void testDelegateWrapperOfInterface() {
+    @ParameterizedTest
+    @MethodSource("provideDelegateFactoryImplementations")
+    public void testDelegateWrapperOfInterface(final @NotNull DelegateFactory delegateFactory) {
         val implementation = mock(SimpleInterface.class);
         when(implementation.getInt()).thenReturn(0xCAFEBABE);
         when(implementation.toString(1)).thenReturn("1");
@@ -29,7 +31,7 @@ class AsmDelegateFactoryTest {
         @SuppressWarnings("unchecked") val factory = (Supplier<SimpleInterface>) mock(Supplier.class);
         when(factory.get()).thenReturn(implementation);
 
-        val wrapper = testTarget.createWrapper(SimpleInterface.class, factory);
+        val wrapper = delegateFactory.createWrapper(SimpleInterface.class, factory);
 
         // test that no unneeded calls are done
         verify(factory, times(0)).get();


### PR DESCRIPTION
# Description

Implement `DelegateFactory` using `Proxy` API of JDK. This is to support environments lacking ASM API.