### PR TITLE
build: add separate `padla-parent` module

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,9 @@
 ## Supported Versions
 
 | Version      | Supported          |
-| ------------ | ------------------ |
-| [1.0.0-rc.8] | :heavy_check_mark: |
-| < 1.0.0-rc.8 | :x:                |
+|--------------| ------------------ |
+| [1.0.0-rc.9] | :heavy_check_mark: |
+| < 1.0.0-rc.9 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/java-commons/pom.xml
+++ b/java-commons/pom.xml
@@ -5,8 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
-        <artifactId>padla</artifactId>
-        <version>1.0.0-rc.9</version>
+        <artifactId>padla-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../padla-parent</relativePath>
     </parent>
     <artifactId>java-commons</artifactId>
 
@@ -61,10 +62,12 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/java-commons/pom.xml
+++ b/java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
         <artifactId>padla</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-rc.9</version>
     </parent>
     <artifactId>java-commons</artifactId>
 

--- a/padla-bom/pom.xml
+++ b/padla-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
         <artifactId>padla</artifactId>
-        <version>1.0.0-rc.9</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>padla-bom</artifactId>
     <packaging>pom</packaging>
@@ -20,17 +20,17 @@
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>java-commons</artifactId>
-                <version>1.0.0-rc.9</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>reflector</artifactId>
-                <version>1.0.0-rc.9</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>ultimate-messenger</artifactId>
-                <version>1.0.0-rc.9</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/padla-bom/pom.xml
+++ b/padla-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
         <artifactId>padla</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-rc.9</version>
     </parent>
     <artifactId>padla-bom</artifactId>
     <packaging>pom</packaging>
@@ -20,17 +20,17 @@
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>java-commons</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-rc.9</version>
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>reflector</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-rc.9</version>
             </dependency>
             <dependency>
                 <groupId>ru.progrm-jarvis</groupId>
                 <artifactId>ultimate-messenger</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+                <version>1.0.0-rc.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/padla-parent/pom.xml
+++ b/padla-parent/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ru.progrm-jarvis</groupId>
+        <artifactId>padla</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>padla-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>PADLA parent</name>
+    <description>Parent module of PADLA components, this is not intended for use as a dependency</description>
+
+    <modules>
+        <module>../java-commons</module>
+        <module>../reflector</module>
+        <module>../ultimate-messenger</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Own dependencies -->
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>java-commons</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Annotations -->
+
+            <!-- Code generation -->
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.24</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <!-- Documenting -->
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>23.0.0</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <!-- Testing -->
+
+            <!-- BOMs -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>4.6.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -236,19 +236,6 @@
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
-                    <dependencies>
-                        <!-- Manual fix of Plugin crash on latest Java versions -->
-                        <dependency>
-                            <groupId>com.thoughtworks.xstream</groupId>
-                            <artifactId>xstream</artifactId>
-                            <version>1.4.17</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.ogce</groupId>
-                            <artifactId>xpp3</artifactId>
-                            <version>1.1.6</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.progrm-jarvis</groupId>
     <artifactId>padla</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-rc.9</version>
     <modules>
         <module>java-commons</module>
         <module>reflector</module>

--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,20 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.progrm-jarvis</groupId>
     <artifactId>padla</artifactId>
-    <version>1.0.0-rc.9</version>
+    <version>1.0.0-SNAPSHOT</version>
     <modules>
-        <module>java-commons</module>
-        <module>reflector</module>
-        <module>ultimate-messenger</module>
         <module>padla-bom</module>
+        <module>padla-parent</module>
     </modules>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version.minimal>8</java.version.minimal>
-        <!-- Duplicated dependency versions -->
-        <version.mockito>4.6.1</version.mockito>
     </properties>
 
     <name>PADLA for Java</name>
-    <description>Pack of Java utilities for various needs</description>
+    <description>Pack of Java utilities for various needs, this is not intended for use as a dependency</description>
     <url>https://padla.progrm-jarvis.ru/</url>
 
     <inceptionYear>2019</inceptionYear>
@@ -72,7 +68,12 @@
     </developers>
 
     <build>
-        <defaultGoal>verify install</defaultGoal>
+        <defaultGoal>
+            <!-- required due to use of MultiReleaseJar and Jigsaw modules -->
+            package
+            <!-- snapshots should end up in local Maven repository by default -->
+            install
+        </defaultGoal>
 
         <pluginManagement>
             <plugins>
@@ -243,17 +244,10 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Own dependencies -->
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>java-commons</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>reflector</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+            <!--
+            Optional dependencies: this should be present both in modules and the BOM
+            so that BOM users default to supported library versions
+            -->
 
             <!-- BOMs -->
             <dependency>
@@ -262,16 +256,9 @@
                 <version>9.3</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.8.2</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <optional>true</optional>
             </dependency>
 
-            <!-- Libraries -->
             <!-- Caching -->
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -287,44 +274,6 @@
                 <version>3.29.0-GA</version>
                 <scope>provided</scope>
                 <optional>true</optional>
-            </dependency>
-
-            <!-- Code generation -->
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.24</version>
-                <scope>provided</scope>
-                <optional>true</optional>
-            </dependency>
-
-            <!-- Documenting -->
-            <dependency>
-                <groupId>org.jetbrains</groupId>
-                <artifactId>annotations</artifactId>
-                <version>23.0.0</version>
-                <scope>provided</scope>
-                <optional>true</optional>
-            </dependency>
-
-            <!-- Testing -->
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${version.mockito}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${version.mockito}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/reflector/pom.xml
+++ b/reflector/pom.xml
@@ -5,8 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
-        <artifactId>padla</artifactId>
-        <version>1.0.0-rc.9</version>
+        <artifactId>padla-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../padla-parent</relativePath>
     </parent>
     <artifactId>reflector</artifactId>
 

--- a/reflector/pom.xml
+++ b/reflector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
         <artifactId>padla</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-rc.9</version>
     </parent>
     <artifactId>reflector</artifactId>
 

--- a/ultimate-messenger/pom.xml
+++ b/ultimate-messenger/pom.xml
@@ -5,8 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
-        <artifactId>padla</artifactId>
-        <version>1.0.0-rc.9</version>
+        <artifactId>padla-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../padla-parent</relativePath>
     </parent>
     <artifactId>ultimate-messenger</artifactId>
 

--- a/ultimate-messenger/pom.xml
+++ b/ultimate-messenger/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ru.progrm-jarvis</groupId>
         <artifactId>padla</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-rc.9</version>
     </parent>
     <artifactId>ultimate-messenger</artifactId>
 


### PR DESCRIPTION
# Description

This PR adds a separate `padla-parent` module which is now the parent of `java-commons`, `reflector` and `ultimiate-messenger`.

This is done to remove unndeeded dependencies from `padla-bom` such as JUnit.